### PR TITLE
feat(core): implement Event<T> type

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,7 +9,7 @@ import { defineConfig } from 'eslint/config';
 
 export default defineConfig(
   {
-    ignores: ['eslint.config.mjs', 'dist/**', 'node_modules/**'],
+    ignores: ['eslint.config.mjs', 'vitest.config.ts', 'dist/**', 'node_modules/**'],
   },
   eslint.configs.recommended,
   ...tseslint.configs.strictTypeChecked,

--- a/src/core/event.test.ts
+++ b/src/core/event.test.ts
@@ -1,0 +1,46 @@
+import type { Event, EventContext } from '@loom/core/event.js';
+import { Time } from '@loom/core/time.js';
+import { describe, expect, it } from 'vitest';
+
+describe('Event<T>', () => {
+  it('holds begin, end, and value', () => {
+    const event: Event<string> = {
+      begin: Time.ZERO,
+      end: Time.ONE,
+      value: 'c3',
+    };
+
+    expect(event.begin.eq(Time.ZERO)).toBe(true);
+    expect(event.end.eq(Time.ONE)).toBe(true);
+    expect(event.value).toBe('c3');
+    expect(event.context).toBeUndefined();
+  });
+
+  it('carries an optional context', () => {
+    const context: EventContext = { origin: 'mini', span: [0, 4] };
+    const event: Event<number> = {
+      begin: new Time(1n, 4n),
+      end: new Time(1n, 2n),
+      value: 42,
+      context,
+    };
+
+    expect(event.begin.eq(new Time(1n, 4n))).toBe(true);
+    expect(event.end.eq(new Time(1n, 2n))).toBe(true);
+    expect(event.value).toBe(42);
+    expect(event.context).toEqual(context);
+  });
+
+  it('supports arbitrary value types', () => {
+    const note: Event<{ pitch: number; volume: number }> = {
+      begin: Time.ZERO,
+      end: new Time(1n, 4n),
+      value: { pitch: 48, volume: 5 },
+    };
+
+    expect(note.begin.eq(Time.ZERO)).toBe(true);
+    expect(note.end.eq(new Time(1n, 4n))).toBe(true);
+    expect(note.value.pitch).toBe(48);
+    expect(note.value.volume).toBe(5);
+  });
+});

--- a/src/core/event.ts
+++ b/src/core/event.ts
@@ -1,0 +1,29 @@
+import type { Time } from '@loom/core/time.js';
+
+/**
+ * Context carried alongside an event — origin hints useful for debugging
+ * composed patterns. Free-form because transforms decide what's helpful
+ * to forward (parent pattern name, mini-notation span, etc.).
+ */
+export interface EventContext {
+  readonly [key: string]: unknown;
+}
+
+/**
+ * A single unit of output from a pattern query. Holds a half-open time
+ * interval `[begin, end)`, the value active over that interval, and an
+ * optional context for debugging.
+ *
+ * Events are immutable — transforms produce new events rather than
+ * mutating existing ones.
+ */
+export interface Event<T> {
+  /** Inclusive lower bound in cycles. */
+  readonly begin: Time;
+  /** Exclusive upper bound in cycles. Always strictly greater than `begin`. */
+  readonly end: Time;
+  /** The value active over `[begin, end)`. */
+  readonly value: T;
+  /** Optional origin hints propagated by transforms. */
+  readonly context?: EventContext;
+}

--- a/src/core/event.ts
+++ b/src/core/event.ts
@@ -3,7 +3,11 @@ import type { Time } from '@loom/core/time.js';
 /**
  * Context carried alongside an event — origin hints useful for debugging
  * composed patterns. Free-form because transforms decide what's helpful
- * to forward (parent pattern name, mini-notation span, etc.).
+ * to forward.
+ *
+ * Conventional keys (producers should prefer these over ad-hoc names):
+ * - `origin` — module that produced the event (`'mini'`, `'pure'`, ...)
+ * - `span` — `[startChar, endChar]` source span for mini-notation events
  */
 export interface EventContext {
   readonly [key: string]: unknown;
@@ -20,7 +24,11 @@ export interface EventContext {
 export interface Event<T> {
   /** Inclusive lower bound in cycles. */
   readonly begin: Time;
-  /** Exclusive upper bound in cycles. Always strictly greater than `begin`. */
+  /**
+   * Exclusive upper bound in cycles. By convention strictly greater than
+   * `begin` — producers (e.g. `Pattern.query`) maintain this; consumers
+   * may assume it.
+   */
   readonly end: Time;
   /** The value active over `[begin, end)`. */
   readonly value: T;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,1 +1,2 @@
+export type { Event, EventContext } from '@loom/core/event.js';
 export { Time } from '@loom/core/time.js';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,13 @@
+import { fileURLToPath } from 'node:url';
+
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@loom': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   test: {
     globals: true,
     include: ['src/**/*.test.ts', 'test/**/*.test.ts'],


### PR DESCRIPTION
## Summary
- Adds the `Event<T>` interface — the unit of output from pattern queries, with readonly `begin`, `end`, `value` and optional `context`.
- Re-exports from `@loom/core`.
- Configures vitest to resolve the `@loom/*` path alias so co-located tests can import via the canonical aliases.

Closes #1.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` — 3 tests cover construction, optional context, and parametric value types.