### PR TITLE
refactor(ci): split checks into parallel jobs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(bun run typecheck)",
+      "Bash(bun run lint)",
+      "Bash(bun run lint:fix)",
+      "Bash(bun run format)",
+      "Bash(bun run test)",
+      "Bash(bun run test:watch)",
+      "Bash(bun run test:cov)"
+    ]
+  }
+}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,22 @@
+name: Setup Loom
+description: Install Bun, cache ~/.bun/install/cache, and run bun install. Caller must checkout first.
+
+inputs:
+  bun-version:
+    description: Bun version to install (pinned by the workflow to avoid drift).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ inputs.bun-version }}
+
+    - uses: actions/cache@v4
+      with:
+        path: ~/.bun/install/cache
+        key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+    - run: bun install --frozen-lockfile
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,30 +10,60 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  BUN_VERSION: 1.3.11
+
 jobs:
-  checks:
+  typecheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - uses: oven-sh/setup-bun@v2
+      - uses: ./.github/actions/setup
         with:
-          bun-version: 1.3.11
+          bun-version: ${{ env.BUN_VERSION }}
+      - run: bun run typecheck
 
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - run: bun run lint
 
-      - name: Typecheck
-        run: bun run typecheck
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - run: bun run test
 
-      - name: Lint
-        run: bun run lint
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - run: bun run build
 
-      - name: Test
-        run: bun run test
+  knip:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - run: bunx --bun knip
 
-      - name: Build
-        run: bun run build
-
-      - name: Dead code check
-        run: bunx --bun knip
+  ci-success:
+    if: always()
+    needs: [typecheck, lint, test, build, knip]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 .DS_Store
 .vscode/
 .idea/
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Two bundled changes, one per commit:

### 1. `refactor(ci): split checks into parallel jobs`
- Fans the single `checks` job into 5 parallel jobs — `typecheck`, `lint`, `test`, `build`, `knip` — so failures surface independently instead of short-circuiting the pipeline.
- Adds a `ci-success` umbrella job (`needs: [typecheck, lint, test, build, knip]`, `if: always()`) as the single stable required status for branch protection.
- Centralizes `BUN_VERSION` in a workflow-level env var.
- Caches `~/.bun/install/cache` per job keyed on `bun.lock`.
- Extracts the shared `setup-bun + cache + install` scaffolding into a local composite action at `.github/actions/setup/action.yml`, so each job is 4 steps of meaningful work instead of 5 of boilerplate.

### 2. `chore(tooling): allow bun dev checks without permission prompts`
- Adds `.claude/settings.json` allowing `Bash(bun run {typecheck,lint,lint:fix,format,test,test:watch,test:cov})` so Claude Code sessions don't prompt for these read/lint/test commands.
- Adds `.claude/settings.local.json` to `.gitignore` so contributors' personal overrides stay local even without a global ignore rule.

## Post-merge action
- [ ] Update branch protection on `main` to require the `ci-success` status check (replaces the old `checks`).

## Test plan
- [x] YAML validates and autosquash was run to produce a clean 2-commit history.
- [x] `bun run typecheck`, `bun run lint`, `bun run test` pass locally.
- [x] Composite action correctly scoped — caller does checkout, composite handles setup/cache/install.

## Closed issues
- Closes #35 (composite-action extraction — folded in here instead of a follow-up PR).