### PR TITLE
feat(core): implement Pattern<T> with lazy query

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,2 +1,3 @@
 export type { Event, EventContext } from '@loom/core/event.js';
+export { Pattern, type QueryFunction } from '@loom/core/pattern.js';
 export { Time } from '@loom/core/time.js';

--- a/src/core/pattern.test.ts
+++ b/src/core/pattern.test.ts
@@ -1,0 +1,139 @@
+import type { Event } from '@loom/core/event.js';
+import { Pattern } from '@loom/core/pattern.js';
+import { Time } from '@loom/core/time.js';
+import { describe, expect, it, vi } from 'vitest';
+
+function mkEvent<T>(begin: Time, end: Time, value: T): Event<T> {
+  return { begin, end, value };
+}
+
+describe('Pattern<T>', () => {
+  it('is lazy — the query function is not invoked until query() is called', () => {
+    const queryFunction = vi.fn(() => []);
+    new Pattern(queryFunction);
+    expect(queryFunction).not.toHaveBeenCalled();
+  });
+
+  it('returns events from the underlying query function', () => {
+    const event = mkEvent(Time.ZERO, Time.ONE, 'hello');
+    const pattern = new Pattern(() => [event]);
+
+    expect(pattern.query(Time.ZERO, Time.ONE)).toEqual([event]);
+  });
+
+  it('returns events sorted by begin time', () => {
+    const unordered = [
+      mkEvent(new Time(2n, 4n), new Time(3n, 4n), 'c'),
+      mkEvent(Time.ZERO, new Time(1n, 4n), 'a'),
+      mkEvent(new Time(1n, 4n), new Time(2n, 4n), 'b'),
+    ];
+    const pattern = new Pattern(() => unordered);
+
+    const events = pattern.query(Time.ZERO, Time.ONE);
+    expect(events.map((e) => e.value)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('sorts stably — events sharing a begin time keep input order', () => {
+    const events = [
+      mkEvent(Time.ZERO, new Time(1n, 2n), 'first'),
+      mkEvent(Time.ZERO, Time.ONE, 'second'),
+      mkEvent(Time.ZERO, new Time(3n, 4n), 'third'),
+    ];
+    const pattern = new Pattern(() => events);
+
+    expect(pattern.query(Time.ZERO, Time.ONE).map((e) => e.value)).toEqual([
+      'first',
+      'second',
+      'third',
+    ]);
+  });
+
+  it('returns events that begin exactly at the inclusive lower bound', () => {
+    const event = mkEvent(new Time(1n, 4n), new Time(1n, 2n), 'edge');
+    const pattern = new Pattern(() => [event]);
+
+    expect(pattern.query(new Time(1n, 4n), Time.ONE)).toEqual([event]);
+  });
+
+  it('preserves events whose end extends past the query upper bound', () => {
+    const tail = mkEvent(new Time(3n, 4n), new Time(5n, 4n), 'tail');
+    const pattern = new Pattern(() => [tail]);
+
+    const events = pattern.query(Time.ZERO, Time.ONE);
+    expect(events).toEqual([tail]);
+    expect(events[0]?.end.gt(Time.ONE)).toBe(true);
+  });
+
+  it('returns an empty array when end <= begin without invoking the query function', () => {
+    const queryFunction = vi.fn(() => [mkEvent(Time.ZERO, Time.ONE, 'x')]);
+    const pattern = new Pattern(queryFunction);
+
+    expect(pattern.query(Time.ONE, Time.ZERO)).toEqual([]);
+    expect(pattern.query(Time.ONE, Time.ONE)).toEqual([]);
+    expect(queryFunction).not.toHaveBeenCalled();
+  });
+
+  it('does not mutate the events returned by the query function', () => {
+    const original = [
+      mkEvent(new Time(1n, 2n), Time.ONE, 'b'),
+      mkEvent(Time.ZERO, new Time(1n, 2n), 'a'),
+    ];
+    const snapshot = [...original];
+    const pattern = new Pattern(() => original);
+
+    pattern.query(Time.ZERO, Time.ONE);
+
+    expect(original).toEqual(snapshot);
+  });
+
+  it('is pure — repeated queries over the same interval return matching events', () => {
+    const pattern = new Pattern<number>(() => [mkEvent(Time.ZERO, Time.ONE, 42)]);
+
+    const first = pattern.query(Time.ZERO, Time.ONE);
+    const second = pattern.query(Time.ZERO, Time.ONE);
+
+    expect(first).toEqual(second);
+  });
+
+  describe('map', () => {
+    it('applies fn to each event value and preserves time intervals', () => {
+      const pattern = new Pattern<number>(() => [
+        mkEvent(Time.ZERO, new Time(1n, 2n), 1),
+        mkEvent(new Time(1n, 2n), Time.ONE, 2),
+      ]);
+      const doubled = pattern.map((n) => n * 2);
+      const events = doubled.query(Time.ZERO, Time.ONE);
+
+      expect(events.map((e) => e.value)).toEqual([2, 4]);
+      expect(events[0]?.begin.eq(Time.ZERO)).toBe(true);
+      expect(events[1]?.begin.eq(new Time(1n, 2n))).toBe(true);
+    });
+
+    it('preserves context', () => {
+      const pattern = new Pattern<number>(() => [
+        { begin: Time.ZERO, end: Time.ONE, value: 1, context: { origin: 'test' } },
+      ]);
+      const mapped = pattern.map((n) => n + 1);
+      const events = mapped.query(Time.ZERO, Time.ONE);
+
+      expect(events[0]?.context).toEqual({ origin: 'test' });
+    });
+
+    it('omits context when the source event has none', () => {
+      const pattern = new Pattern<number>(() => [mkEvent(Time.ZERO, Time.ONE, 1)]);
+      const mapped = pattern.map((n) => n);
+      const events = mapped.query(Time.ZERO, Time.ONE);
+
+      expect(events[0]).not.toHaveProperty('context');
+    });
+
+    it('returns a new pattern — the original is untouched', () => {
+      const pattern = new Pattern<number>(() => [mkEvent(Time.ZERO, Time.ONE, 1)]);
+      const mapped = pattern.map((n) => n * 10);
+
+      expect(mapped).not.toBe(pattern);
+      expect(pattern.query(Time.ZERO, Time.ONE)[0]?.value).toBe(1);
+      expect(mapped.query(Time.ZERO, Time.ONE)[0]?.value).toBe(10);
+    });
+  });
+});

--- a/src/core/pattern.ts
+++ b/src/core/pattern.ts
@@ -1,0 +1,68 @@
+import type { Event } from '@loom/core/event.js';
+import { Time } from '@loom/core/time.js';
+
+/**
+ * Signature of the lazy query a pattern wraps. Given a half-open time
+ * interval it returns the events active within. Custom implementations
+ * may return events whose `end` extends past the query's `end` — the
+ * wrapping `Pattern` preserves them so consumers can render tails
+ * across cycle boundaries.
+ */
+export type QueryFunction<T> = (begin: Time, end: Time) => Event<T>[];
+
+/**
+ * The core abstraction. A `Pattern<T>` is a lazy query over rational
+ * time — the event list is produced on demand when `query` is called.
+ * Patterns are pure: given the same interval, they always return the
+ * same events.
+ */
+export class Pattern<T> {
+  private readonly queryFunction: QueryFunction<T>;
+
+  constructor(queryFunction: QueryFunction<T>) {
+    this.queryFunction = queryFunction;
+  }
+
+  /**
+   * Queries the pattern over `[begin, end)` and returns the events that
+   * fall within that interval, sorted by begin time. Events may extend
+   * past `end`.
+   *
+   * @param begin - Inclusive lower bound (cycles)
+   * @param end - Exclusive upper bound (cycles)
+   * @returns Events sorted by begin time
+   */
+  query(begin: Time, end: Time): Event<T>[] {
+    if (end.lte(begin)) {
+      return [];
+    }
+    const events = this.queryFunction(begin, end);
+    return events.toSorted((a, b) => {
+      if (a.begin.lt(b.begin)) {
+        return -1;
+      }
+      if (a.begin.gt(b.begin)) {
+        return 1;
+      }
+      return 0;
+    });
+  }
+
+  /**
+   * Maps each event's value through `fn`, preserving time intervals
+   * and context. Returns a new Pattern — the original is untouched.
+   *
+   * @param fn - Function applied to each event value
+   * @returns A new Pattern carrying the mapped values
+   */
+  map<U>(fn: (value: T) => U): Pattern<U> {
+    return new Pattern<U>((begin, end) =>
+      this.query(begin, end).map((event) => ({
+        begin: event.begin,
+        end: event.end,
+        value: fn(event.value),
+        ...(event.context === undefined ? {} : { context: event.context }),
+      })),
+    );
+  }
+}

--- a/src/core/time.test.ts
+++ b/src/core/time.test.ts
@@ -1,0 +1,189 @@
+import { Time } from '@loom/core/time.js';
+import { describe, expect, it } from 'vitest';
+
+describe('Time', () => {
+  describe('construction', () => {
+    it('normalizes to canonical form via gcd reduction', () => {
+      const t = new Time(4n, 8n);
+      expect(t.num).toBe(1n);
+      expect(t.den).toBe(2n);
+    });
+
+    it('accepts number literals', () => {
+      const t = new Time(3, 4);
+      expect(t.num).toBe(3n);
+      expect(t.den).toBe(4n);
+    });
+
+    it('defaults denominator to 1', () => {
+      const t = new Time(5n);
+      expect(t.num).toBe(5n);
+      expect(t.den).toBe(1n);
+    });
+
+    it('moves negative sign to the numerator', () => {
+      const t = new Time(1n, -2n);
+      expect(t.num).toBe(-1n);
+      expect(t.den).toBe(2n);
+    });
+
+    it('keeps a negative numerator negative', () => {
+      const t = new Time(-3n, 4n);
+      expect(t.num).toBe(-3n);
+      expect(t.den).toBe(4n);
+    });
+
+    it('reduces two negatives to a positive', () => {
+      const t = new Time(-2n, -4n);
+      expect(t.num).toBe(1n);
+      expect(t.den).toBe(2n);
+    });
+
+    it('rejects a zero denominator', () => {
+      expect(() => new Time(1n, 0n)).toThrow('Time denominator cannot be zero');
+    });
+  });
+
+  describe('constants', () => {
+    it('exposes ZERO and ONE', () => {
+      expect(Time.ZERO.num).toBe(0n);
+      expect(Time.ZERO.den).toBe(1n);
+      expect(Time.ONE.num).toBe(1n);
+      expect(Time.ONE.den).toBe(1n);
+    });
+  });
+
+  describe('Time.from', () => {
+    it('handles integers', () => {
+      const t = Time.from(5);
+      expect(t.eq(new Time(5n, 1n))).toBe(true);
+    });
+
+    it('handles finite decimals', () => {
+      const t = Time.from(0.25);
+      expect(t.eq(new Time(1n, 4n))).toBe(true);
+    });
+
+    it('handles negative decimals', () => {
+      const t = Time.from(-0.5);
+      expect(t.eq(new Time(-1n, 2n))).toBe(true);
+    });
+
+    it('preserves ~12 digits of decimal precision', () => {
+      const t = Time.from(0.123_456_789_012);
+      expect(t.eq(new Time(123_456_789_012n, 10n ** 12n))).toBe(true);
+    });
+
+    it('rejects non-finite values', () => {
+      expect(() => Time.from(Number.NaN)).toThrow(TypeError);
+      expect(() => Time.from(Number.POSITIVE_INFINITY)).toThrow(TypeError);
+    });
+  });
+
+  describe('arithmetic', () => {
+    it('add', () => {
+      expect(new Time(1n, 4n).add(new Time(1n, 2n)).eq(new Time(3n, 4n))).toBe(true);
+    });
+
+    it('sub', () => {
+      expect(new Time(3n, 4n).sub(new Time(1n, 2n)).eq(new Time(1n, 4n))).toBe(true);
+    });
+
+    it('mul', () => {
+      expect(new Time(2n, 3n).mul(new Time(3n, 4n)).eq(new Time(1n, 2n))).toBe(true);
+    });
+
+    it('div', () => {
+      expect(new Time(1n, 2n).div(new Time(1n, 4n)).eq(new Time(2n, 1n))).toBe(true);
+    });
+
+    it('rejects division by a zero numerator', () => {
+      expect(() => Time.ONE.div(Time.ZERO)).toThrow('division by zero');
+    });
+  });
+
+  describe('comparison', () => {
+    const a = new Time(1n, 4n);
+    const b = new Time(1n, 2n);
+    const aCopy = new Time(2n, 8n);
+
+    it('eq', () => {
+      expect(a.eq(aCopy)).toBe(true);
+      expect(a.eq(b)).toBe(false);
+    });
+
+    it('lt / lte', () => {
+      expect(a.lt(b)).toBe(true);
+      expect(a.lt(aCopy)).toBe(false);
+      expect(a.lte(aCopy)).toBe(true);
+      expect(b.lte(a)).toBe(false);
+    });
+
+    it('gt / gte', () => {
+      expect(b.gt(a)).toBe(true);
+      expect(a.gt(aCopy)).toBe(false);
+      expect(a.gte(aCopy)).toBe(true);
+      expect(a.gte(b)).toBe(false);
+    });
+
+    it('min / max', () => {
+      expect(a.min(b).eq(a)).toBe(true);
+      expect(a.max(b).eq(b)).toBe(true);
+      expect(b.min(a).eq(a)).toBe(true);
+      expect(b.max(a).eq(b)).toBe(true);
+      expect(a.min(aCopy).eq(a)).toBe(true);
+      expect(a.max(aCopy).eq(a)).toBe(true);
+    });
+  });
+
+  describe('very large values', () => {
+    it('stays exact beyond Number.MAX_SAFE_INTEGER via bigint arithmetic', () => {
+      const big = new Time(10n ** 30n, 10n ** 15n);
+      expect(big.eq(new Time(10n ** 15n, 1n))).toBe(true);
+    });
+
+    it('preserves precision when adding two huge fractions', () => {
+      const a = new Time(10n ** 20n + 1n, 10n ** 20n);
+      const b = new Time(1n, 10n ** 20n);
+      expect(a.add(b).eq(new Time(10n ** 20n + 2n, 10n ** 20n))).toBe(true);
+    });
+  });
+
+  describe('floor and fract', () => {
+    it('floors a positive fractional time toward zero', () => {
+      expect(new Time(7n, 4n).floor().eq(new Time(1n, 1n))).toBe(true);
+    });
+
+    it('floors a negative fractional time toward negative infinity', () => {
+      expect(new Time(-7n, 4n).floor().eq(new Time(-2n, 1n))).toBe(true);
+    });
+
+    it('leaves integers unchanged', () => {
+      expect(new Time(3n, 1n).floor().eq(new Time(3n, 1n))).toBe(true);
+      expect(new Time(-3n, 1n).floor().eq(new Time(-3n, 1n))).toBe(true);
+    });
+
+    it('returns the fractional part in [0, 1)', () => {
+      expect(new Time(7n, 4n).fract().eq(new Time(3n, 4n))).toBe(true);
+      expect(new Time(-7n, 4n).fract().eq(new Time(1n, 4n))).toBe(true);
+      expect(new Time(3n, 1n).fract().eq(Time.ZERO)).toBe(true);
+    });
+  });
+
+  describe('toNumber and toString', () => {
+    it('converts to number', () => {
+      expect(new Time(1n, 4n).toNumber()).toBe(0.25);
+      expect(new Time(5n, 1n).toNumber()).toBe(5);
+    });
+
+    it('renders integers bare', () => {
+      expect(new Time(5n, 1n).toString()).toBe('5');
+      expect(new Time(-5n, 1n).toString()).toBe('-5');
+    });
+
+    it('renders fractions as "num/den"', () => {
+      expect(new Time(3n, 4n).toString()).toBe('3/4');
+      expect(new Time(-1n, 2n).toString()).toBe('-1/2');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Core pattern-algebra abstraction. A `Pattern<T>` wraps a lazy query function `(begin, end) → Event<T>[]` and never evaluates until `query` is called. Events are returned sorted stably by begin time — tails may extend past the query's upper bound and are preserved so adapters can render cross-cycle notes.

Also ships `Pattern.map` (value transformation preserving time/context) as immediate groundwork for transforms, since it's eight lines and tested alongside the query contract.

Closes #1-dependent work for #2.

## Also in this PR

Full test coverage for `src/core/time.ts` (rational construction, normalization, arithmetic, comparison, floor/fract, conversion, very-large bigint precision). Required because the CI coverage threshold (80/75/80/80) was failing without it — Time was scaffolded pre-backlog and untested. This closes the Time portion of #4; Event tests already landed with #1.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` — 47 tests across Event, Pattern, Time
- [x] `bun run test:cov` — 100% statements / 97.61% branches / 100% functions / 100% lines (only the defensive `gcd(0, 0)` path in `time.ts` is unreached, and the constructor guards against reaching it)

## Review loop

Self-review cycled once, applied 7 refinements (stable-sort test, QueryFunction JSDoc contract, inclusive-begin and tail-preservation tests, reverse `min`/`max`, `Time.from` precision test, negative-integer `toString`, very-large bigint test), landed via autosquashed fixups. History is 2 clean commits.