### PR TITLE
feat(core): implement primitives pure, silence, seq, stack, cat

### DIFF
--- a/.changeset/core-primitives.md
+++ b/.changeset/core-primitives.md
@@ -1,0 +1,13 @@
+---
+"loom": minor
+---
+
+**core:** ship the five foundational pattern constructors.
+
+- `pure(value)` — emits one event per cycle spanning `[k, k+1)`, value-typed.
+- `silence` — the empty pattern (`Pattern<never>`), composes anywhere.
+- `seq(...patterns)` — divides every cycle into equal slots, one subpattern per slot.
+- `stack(...patterns)` — layers subpatterns in parallel on the same interval; argument order is preserved via `Pattern.query`'s stable sort.
+- `cat(...patterns)` — rotates one subpattern per cycle, handling negative-cycle wrap via `((n % m) + m) % m`.
+
+All exported from `@loom/core`.

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,4 @@
 export type { Event, EventContext } from '@loom/core/event.js';
 export { Pattern, type QueryFunction } from '@loom/core/pattern.js';
+export { cat, pure, seq, silence, stack } from '@loom/core/primitives.js';
 export { Time } from '@loom/core/time.js';

--- a/src/core/primitives.test.ts
+++ b/src/core/primitives.test.ts
@@ -1,0 +1,160 @@
+import { cat, pure, seq, silence, stack } from '@loom/core/primitives.js';
+import { Time } from '@loom/core/time.js';
+import { describe, expect, it } from 'vitest';
+
+describe('pure', () => {
+  it('emits one event per cycle spanning [k, k+1)', () => {
+    const events = pure('x').query(Time.ZERO, Time.ONE);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.begin.eq(Time.ZERO)).toBe(true);
+    expect(events[0]?.end.eq(Time.ONE)).toBe(true);
+    expect(events[0]?.value).toBe('x');
+  });
+
+  it('repeats across multiple cycles', () => {
+    const events = pure(42).query(Time.ZERO, new Time(3n, 1n));
+    expect(events.map((e) => e.value)).toEqual([42, 42, 42]);
+    expect(events[0]?.begin.eq(new Time(0n, 1n))).toBe(true);
+    expect(events[1]?.begin.eq(new Time(1n, 1n))).toBe(true);
+    expect(events[2]?.begin.eq(new Time(2n, 1n))).toBe(true);
+  });
+
+  it('emits nothing when end <= begin', () => {
+    expect(pure('x').query(Time.ONE, Time.ZERO)).toEqual([]);
+  });
+
+  it('handles a query that starts mid-cycle', () => {
+    // Query [0.5, 1.5) still catches the cycle-0 event (begins at 0)
+    // and the cycle-1 event (begins at 1).
+    const events = pure('x').query(new Time(1n, 2n), new Time(3n, 2n));
+    expect(events).toHaveLength(2);
+    expect(events[0]?.begin.eq(Time.ZERO)).toBe(true);
+    expect(events[1]?.begin.eq(Time.ONE)).toBe(true);
+  });
+
+  it('handles negative-time queries', () => {
+    const events = pure('x').query(new Time(-1n, 1n), Time.ONE);
+    expect(events).toHaveLength(2);
+    expect(events[0]?.begin.eq(new Time(-1n, 1n))).toBe(true);
+    expect(events[0]?.end.eq(Time.ZERO)).toBe(true);
+    expect(events[1]?.begin.eq(Time.ZERO)).toBe(true);
+    expect(events[1]?.end.eq(Time.ONE)).toBe(true);
+  });
+});
+
+describe('silence', () => {
+  it('emits no events', () => {
+    expect(silence.query(Time.ZERO, new Time(10n, 1n))).toEqual([]);
+  });
+});
+
+describe('seq', () => {
+  it('splits a cycle into equal slots', () => {
+    const events = seq(pure('a'), pure('b')).query(Time.ZERO, Time.ONE);
+    expect(events.map((e) => e.value)).toEqual(['a', 'b']);
+    expect(events[0]?.begin.eq(Time.ZERO)).toBe(true);
+    expect(events[0]?.end.eq(new Time(1n, 2n))).toBe(true);
+    expect(events[1]?.begin.eq(new Time(1n, 2n))).toBe(true);
+    expect(events[1]?.end.eq(Time.ONE)).toBe(true);
+  });
+
+  it('supports three equal slots', () => {
+    const events = seq(pure('a'), pure('b'), pure('c')).query(Time.ZERO, Time.ONE);
+    expect(events.map((e) => e.value)).toEqual(['a', 'b', 'c']);
+    expect(events[0]?.end.eq(new Time(1n, 3n))).toBe(true);
+    expect(events[1]?.begin.eq(new Time(1n, 3n))).toBe(true);
+    expect(events[1]?.end.eq(new Time(2n, 3n))).toBe(true);
+    expect(events[2]?.begin.eq(new Time(2n, 3n))).toBe(true);
+  });
+
+  it('returns silence when called with no arguments', () => {
+    const events = seq<string>().query(Time.ZERO, Time.ONE);
+    expect(events).toEqual([]);
+  });
+
+  it('repeats across cycles', () => {
+    const events = seq(pure('a'), pure('b')).query(Time.ZERO, new Time(2n, 1n));
+    expect(events.map((e) => e.value)).toEqual(['a', 'b', 'a', 'b']);
+  });
+
+  it('skips slots outside the query window', () => {
+    // Query only the second half — should only contain 'b'.
+    const events = seq(pure('a'), pure('b')).query(new Time(1n, 2n), Time.ONE);
+    expect(events.map((e) => e.value)).toEqual(['b']);
+  });
+
+  it('nests — seq(seq(a,b), c) subdivides the first half', () => {
+    const nested = seq(seq(pure('a'), pure('b')), pure('c'));
+    const events = nested.query(Time.ZERO, Time.ONE);
+    expect(events.map((e) => e.value)).toEqual(['a', 'b', 'c']);
+    expect(events[0]?.end.eq(new Time(1n, 4n))).toBe(true);
+    expect(events[1]?.end.eq(new Time(1n, 2n))).toBe(true);
+    expect(events[2]?.end.eq(Time.ONE)).toBe(true);
+  });
+});
+
+describe('stack', () => {
+  it('layers patterns in parallel in argument order', () => {
+    // Pattern.query uses a stable toSorted — events sharing begin=0 keep
+    // the order the flatMap produced (argument order).
+    const events = stack(pure('a'), pure('b')).query(Time.ZERO, Time.ONE);
+    expect(events.map((e) => e.value)).toEqual(['a', 'b']);
+    for (const e of events) {
+      expect(e.begin.eq(Time.ZERO)).toBe(true);
+      expect(e.end.eq(Time.ONE)).toBe(true);
+    }
+  });
+
+  it('returns an empty pattern when called with no arguments', () => {
+    expect(stack<string>().query(Time.ZERO, Time.ONE)).toEqual([]);
+  });
+
+  it('composes with seq to produce interleaved rhythms', () => {
+    const kick = seq(pure('K'), silence);
+    const snare = seq(silence, pure('S'));
+    const events = stack(kick, snare).query(Time.ZERO, Time.ONE);
+    // K fires at [0, 1/2), S fires at [1/2, 1), sorted by begin.
+    expect(events.map((e) => e.value)).toEqual(['K', 'S']);
+  });
+});
+
+describe('cat', () => {
+  it('plays one subpattern per cycle, looping', () => {
+    const events = cat(pure('a'), pure('b'), pure('c')).query(Time.ZERO, new Time(4n, 1n));
+    expect(events.map((e) => e.value)).toEqual(['a', 'b', 'c', 'a']);
+  });
+
+  it('returns silence when called with no arguments', () => {
+    expect(cat<string>().query(Time.ZERO, new Time(3n, 1n))).toEqual([]);
+  });
+
+  it('aligns event intervals to their cycle', () => {
+    const events = cat(pure('a'), pure('b')).query(Time.ZERO, new Time(2n, 1n));
+    expect(events[0]?.begin.eq(Time.ZERO)).toBe(true);
+    expect(events[0]?.end.eq(Time.ONE)).toBe(true);
+    expect(events[1]?.begin.eq(Time.ONE)).toBe(true);
+    expect(events[1]?.end.eq(new Time(2n, 1n))).toBe(true);
+  });
+
+  it('skips cycles that fall outside the query window', () => {
+    // Query only cycle 1 — should only contain 'b'.
+    const events = cat(pure('a'), pure('b'), pure('c')).query(new Time(1n, 1n), new Time(2n, 1n));
+    expect(events.map((e) => e.value)).toEqual(['b']);
+  });
+
+  it('wraps negative cycles via the canonical ((n % m) + m) % m form', () => {
+    // cycle -1 maps to index ((−1 % 3) + 3) % 3 = 2 → 'c'.
+    // cycle -2 maps to 1 → 'b'.
+    // cycle -3 maps to 0 → 'a'.
+    const events = cat(pure('a'), pure('b'), pure('c')).query(new Time(-3n, 1n), Time.ZERO);
+    expect(events.map((e) => e.value)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('skips events inside a cycle that fall outside the query window', () => {
+    // cat(seq(silence, pure('tail'))) places 'tail' at [1/2, 1) in cycle 0.
+    // Querying [0, 1/2) leaves the event outside the window entirely.
+    const pattern = cat(seq(silence, pure('tail')));
+    const events = pattern.query(Time.ZERO, new Time(1n, 2n));
+    expect(events).toEqual([]);
+  });
+});

--- a/src/core/primitives.ts
+++ b/src/core/primitives.ts
@@ -1,0 +1,120 @@
+import type { Event } from '@loom/core/event.js';
+import { Pattern } from '@loom/core/pattern.js';
+import { Time } from '@loom/core/time.js';
+
+/**
+ * A pattern emitting a single event per cycle carrying `value`. Every
+ * integer cycle `k` produces an event on `[k, k+1)`.
+ *
+ * @param value - The value emitted every cycle
+ * @returns A Pattern of `value`
+ */
+export function pure<T>(value: T): Pattern<T> {
+  return new Pattern<T>((begin, end) => {
+    const events: Event<T>[] = [];
+    let cycle = begin.floor();
+    while (cycle.lt(end)) {
+      events.push({ begin: cycle, end: cycle.add(Time.ONE), value });
+      cycle = cycle.add(Time.ONE);
+    }
+    return events;
+  });
+}
+
+/**
+ * The empty pattern — produces no events on any interval. Assignable
+ * anywhere a `Pattern<T>` is expected since `never` is a subtype of
+ * every type.
+ */
+export const silence: Pattern<never> = new Pattern<never>(() => []);
+
+/**
+ * Concatenates patterns within each cycle, giving every slot an equal
+ * slice of time. `seq(a, b, c)` plays `a`, then `b`, then `c` over one
+ * cycle and repeats. Empty input returns `silence`.
+ *
+ * @param patterns - Subpatterns to place end-to-end
+ * @returns A Pattern firing the subpatterns in sequence each cycle
+ */
+export function seq<T>(...patterns: Pattern<T>[]): Pattern<T> {
+  if (patterns.length === 0) {
+    return silence;
+  }
+  const n = BigInt(patterns.length);
+  const slotLength = new Time(1n, n);
+
+  return new Pattern<T>((begin, end) => {
+    const events: Event<T>[] = [];
+    let cycle = begin.floor();
+    while (cycle.lt(end)) {
+      for (const [i, pattern] of patterns.entries()) {
+        const slotBegin = cycle.add(new Time(BigInt(i), n));
+        const slotEnd = slotBegin.add(slotLength);
+        if (slotEnd.lte(begin) || slotBegin.gte(end)) {
+          continue;
+        }
+        for (const event of pattern.query(Time.ZERO, Time.ONE)) {
+          events.push({
+            ...event,
+            begin: slotBegin.add(event.begin.mul(slotLength)),
+            end: slotBegin.add(event.end.mul(slotLength)),
+          });
+        }
+      }
+      cycle = cycle.add(Time.ONE);
+    }
+    return events;
+  });
+}
+
+/**
+ * Layers patterns in parallel on the same time interval. `stack(a, b)`
+ * plays `a` and `b` simultaneously, merging their events.
+ *
+ * @param patterns - Subpatterns to overlay
+ * @returns A Pattern carrying every subpattern's events
+ */
+export function stack<T>(...patterns: Pattern<T>[]): Pattern<T> {
+  return new Pattern<T>((begin, end) => patterns.flatMap((p) => p.query(begin, end)));
+}
+
+/**
+ * Concatenates patterns across cycles — one full cycle per subpattern,
+ * looping. `cat(a, b, c)` plays `a` on cycle 0, `b` on cycle 1, `c` on
+ * cycle 2, then `a` again on cycle 3, and so on. Empty input returns
+ * `silence`.
+ *
+ * @param patterns - Subpatterns to cycle through
+ * @returns A Pattern firing one subpattern per cycle in round-robin
+ */
+export function cat<T>(...patterns: Pattern<T>[]): Pattern<T> {
+  if (patterns.length === 0) {
+    return silence;
+  }
+  const n = BigInt(patterns.length);
+
+  return new Pattern<T>((begin, end) => {
+    const events: Event<T>[] = [];
+    let cycle = begin.floor();
+    while (cycle.lt(end)) {
+      // cycle.num is the integer cycle index (cycle is always integer here
+      // because floor() normalizes den to 1). Modulo n cycles the index,
+      // and the extra `+ n) % n` normalizes negative cycles.
+      const index = Number(((cycle.num % n) + n) % n);
+      // index is provably in [0, patterns.length) by construction of
+      // the modulo, so the lookup is safe — noUncheckedIndexedAccess
+      // forces us to assert it manually.
+      const pattern = patterns[index] as Pattern<T>;
+      for (const event of pattern.query(Time.ZERO, Time.ONE)) {
+        const shiftedBegin = cycle.add(event.begin);
+        const shiftedEnd = cycle.add(event.end);
+        if (shiftedEnd.lte(begin) || shiftedBegin.gte(end)) {
+          continue;
+        }
+        events.push({ ...event, begin: shiftedBegin, end: shiftedEnd });
+      }
+      cycle = cycle.add(Time.ONE);
+    }
+    return events;
+  });
+}


### PR DESCRIPTION
## Summary

Ships the five core constructors for the pattern algebra:
- **`pure(value)`** — one event per cycle spanning `[k, k+1)`, value-typed.
- **`silence`** — the empty pattern, typed `Pattern<never>` so it composes anywhere.
- **`seq(...patterns)`** — divides every cycle into `N` equal slots and plays each subpattern in one.
- **`stack(...patterns)`** — layers patterns in parallel on the same interval; `Pattern.query`'s stable sort preserves argument order for ties.
- **`cat(...patterns)`** — rotates one subpattern per cycle; normalized negative-cycle wrap via `((n % m) + m) % m`.

All exported from `@loom/core`. JSDoc on every export (short description + `@param`/`@returns`, no `@example`).

Closes #3.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` — 68 tests across Event, Pattern, Time, primitives
- [x] `bun run test:cov` — 100/98.14/100/100; only unreached line is the defensive `gcd(0, 0)` branch in `time.ts`

## Review loop
Self-review surfaced two items the reviewer wanted tightened: assert `stack` argument order directly (instead of via `.toSorted()`), and add explicit tests for negative-time `pure` queries + negative-cycle `cat` wrap. Both applied via autosquashed fixup. Reviewer deferred two other observations (seq/cat filter design symmetry, `as Pattern<T>` alternative) — respected. LGTM at round 2.