### PR TITLE
chore(tooling): convert commitlint.config.js to ESM

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -69,7 +69,7 @@ const keywords = [
   'claude',
 ];
 
-module.exports = {
+export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'scope-enum': [2, 'always', [...sources, ...keywords]],


### PR DESCRIPTION
## Summary

One-line change: `module.exports = { ... }` → `export default { ... }` in `commitlint.config.js`. The file is now a proper ES module, consistent with `"type": "module"` in package.json.

### Why

Previously, `commitlint.config.js` contained CommonJS syntax in an ESM package. The husky commit-msg hook uses `bunx --bun commitlint --edit`, and Bun tolerates CommonJS in ESM context, so commits kept working. But any contributor running commitlint via plain Node (`node -e "import('./commitlint.config.js')"`) hit `ReferenceError: module is not defined`. This removes that foot-gun.

Closes #39.

### Verified

- `node -e "import('./commitlint.config.js').then(m => console.log(m.default.extends))"` → `[ '@commitlint/config-conventional' ]` ✓
- `bunx --bun commitlint` on a valid message (`chore(tooling): …`) → exit 0 ✓
- `bunx --bun commitlint` on an invalid message (no type/scope) → exit 1 with `scope-empty` / `type-empty` ✓
- Husky hook still blocks bad messages (tested against `.husky/commit-msg` directly) ✓
- `bun run typecheck`, `bun run lint`, `bun run test` all green ✓

### Intentionally out

- No rename to `.mjs`. Under `"type": "module"`, `.js` *is* ESM — a rename would buy nothing.
- No changeset — tooling-only change with no user-facing impact (per CLAUDE.md rule 5).

## Review loop
Self-review LGTM'd in one round. One AC-wording nit about `require()` vs `import()` on older Node addressed via a clarifying comment on #39.