### PR TITLE
feat(pico8): define the public type model

### DIFF
--- a/.changeset/pico8-types.md
+++ b/.changeset/pico8-types.md
@@ -1,0 +1,5 @@
+---
+"loom": minor
+---
+
+**pico8:** define the public type surface — `Note`, `Rest`, `SfxStep`, `Sfx`, `MusicChannel`, `MusicPattern`, `LoopRange`, `Song`, plus the `Pitch`, `Volume`, `InstrumentId`, `EffectId`, `Speed` aliases and their range constants (`PITCH_MAX`, `VOLUME_MAX`, `STEPS_PER_SFX`, `MUSIC_CHANNELS_MAX`, …). Exported from `@loom/pico8`.

--- a/src/pico8/index.ts
+++ b/src/pico8/index.ts
@@ -1,10 +1,30 @@
-// Public surface of the PICO-8-flavored layer.
-//
-// Populated as the roadmap lands:
-// - types (Note, SfxStep, MusicChannel, SongStep)
-// - instruments (8 built-in waveforms + custom slots)
-// - effects (8 per-step effects)
-// - sfx builder (32-step constraint, speed, note validation)
-// - music builder (4-channel stack)
-// - song builder (music pattern chain with loop markers)
-export {};
+export {
+  EFFECT_MAX,
+  EFFECT_MIN,
+  type EffectId,
+  INSTRUMENT_BUILTIN_MAX,
+  INSTRUMENT_MAX,
+  INSTRUMENT_MIN,
+  type InstrumentId,
+  type LoopRange,
+  MUSIC_CHANNELS_MAX,
+  type MusicChannel,
+  type MusicPattern,
+  type Note,
+  type Pitch,
+  PITCH_MAX,
+  PITCH_MIN,
+  type Rest,
+  type Sfx,
+  type SfxChannel,
+  type SfxStep,
+  type SilenceChannel,
+  type Song,
+  type Speed,
+  SPEED_MAX,
+  SPEED_MIN,
+  STEPS_PER_SFX,
+  type Volume,
+  VOLUME_MAX,
+  VOLUME_MIN,
+} from '@loom/pico8/types.js';

--- a/src/pico8/types.test.ts
+++ b/src/pico8/types.test.ts
@@ -1,0 +1,132 @@
+import {
+  EFFECT_MAX,
+  EFFECT_MIN,
+  INSTRUMENT_BUILTIN_MAX,
+  INSTRUMENT_MAX,
+  INSTRUMENT_MIN,
+  type LoopRange,
+  MUSIC_CHANNELS_MAX,
+  type MusicChannel,
+  type MusicPattern,
+  type Note,
+  PITCH_MAX,
+  PITCH_MIN,
+  type Rest,
+  type Sfx,
+  type SfxStep,
+  type Song,
+  SPEED_MAX,
+  SPEED_MIN,
+  STEPS_PER_SFX,
+  VOLUME_MAX,
+  VOLUME_MIN,
+} from '@loom/pico8/types.js';
+import { describe, expect, it } from 'vitest';
+
+describe('pico8/types', () => {
+  describe('range constants', () => {
+    it('matches PICO-8 tracker bounds', () => {
+      expect(PITCH_MIN).toBe(0);
+      expect(PITCH_MAX).toBe(63);
+      expect(VOLUME_MIN).toBe(0);
+      expect(VOLUME_MAX).toBe(7);
+      expect(INSTRUMENT_MIN).toBe(0);
+      expect(INSTRUMENT_BUILTIN_MAX).toBe(7);
+      expect(INSTRUMENT_MAX).toBe(15);
+      expect(EFFECT_MIN).toBe(0);
+      expect(EFFECT_MAX).toBe(7);
+      expect(SPEED_MIN).toBe(1);
+      expect(SPEED_MAX).toBe(255);
+      expect(STEPS_PER_SFX).toBe(32);
+      expect(MUSIC_CHANNELS_MAX).toBe(4);
+    });
+  });
+
+  describe('Note and Rest', () => {
+    it('Note carries the full attribute set', () => {
+      const note: Note = {
+        kind: 'note',
+        pitch: 48,
+        instrument: 0,
+        volume: 5,
+        effect: 0,
+      };
+      expect(note.kind).toBe('note');
+      expect(note.pitch).toBe(48);
+      expect(note.instrument).toBe(0);
+      expect(note.volume).toBe(5);
+      expect(note.effect).toBe(0);
+    });
+
+    it('Rest is the silent step', () => {
+      const rest: Rest = { kind: 'rest' };
+      expect(rest.kind).toBe('rest');
+    });
+
+    it('SfxStep discriminates by kind', () => {
+      const steps: SfxStep[] = [
+        { kind: 'note', pitch: 0, instrument: 0, volume: 0, effect: 0 },
+        { kind: 'rest' },
+      ];
+      const [first, second] = steps;
+      if (first?.kind === 'note') {
+        expect(first.pitch).toBe(0);
+      } else {
+        expect.fail('first step should be a note');
+      }
+      expect(second?.kind).toBe('rest');
+    });
+  });
+
+  describe('Sfx', () => {
+    it('holds steps and speed', () => {
+      const sfx: Sfx = {
+        steps: Array.from({ length: STEPS_PER_SFX }, () => ({ kind: 'rest' }) as const),
+        speed: 16,
+      };
+      expect(sfx.steps).toHaveLength(STEPS_PER_SFX);
+      expect(sfx.speed).toBe(16);
+    });
+  });
+
+  describe('MusicChannel', () => {
+    it('discriminates between sfx and silence variants', () => {
+      const sfx: Sfx = {
+        steps: Array.from({ length: STEPS_PER_SFX }, () => ({ kind: 'rest' }) as const),
+        speed: 16,
+      };
+      const channels: MusicChannel[] = [{ kind: 'sfx', sfx }, { kind: 'silence' }];
+
+      const [first, second] = channels;
+      if (first?.kind === 'sfx') {
+        expect(first.sfx.speed).toBe(16);
+      } else {
+        expect.fail('first channel should reference the sfx');
+      }
+      expect(second?.kind).toBe('silence');
+    });
+  });
+
+  describe('MusicPattern and Song', () => {
+    it('MusicPattern holds up to MUSIC_CHANNELS_MAX channels', () => {
+      const pattern: MusicPattern = {
+        channels: Array.from({ length: MUSIC_CHANNELS_MAX }, () => ({ kind: 'silence' }) as const),
+      };
+      expect(pattern.channels).toHaveLength(MUSIC_CHANNELS_MAX);
+    });
+
+    it('Song without loop plays once', () => {
+      const song: Song = { patterns: [{ channels: [] }] };
+      expect(song.patterns).toHaveLength(1);
+      expect(song.loop).toBeUndefined();
+    });
+
+    it('Song with loop carries start/end positions', () => {
+      const loop: LoopRange = { start: 1, end: 3 };
+      const song: Song = { patterns: [{ channels: [] }, { channels: [] }], loop };
+      expect(song.patterns).toHaveLength(2);
+      expect(song.loop?.start).toBe(1);
+      expect(song.loop?.end).toBe(3);
+    });
+  });
+});

--- a/src/pico8/types.ts
+++ b/src/pico8/types.ts
@@ -1,0 +1,140 @@
+/**
+ * PICO-8 pitch value. Valid range is `0..63` (C-1 up to D#6 in tracker
+ * convention). Not a branded type — range checks live at the adapter
+ * boundary, not the type layer.
+ */
+export type Pitch = number;
+
+/** Inclusive min pitch accepted by PICO-8's tracker. */
+export const PITCH_MIN = 0;
+/** Inclusive max pitch accepted by PICO-8's tracker. */
+export const PITCH_MAX = 63;
+
+/**
+ * Per-step volume. Valid range is `0..7` — 0 is silent, 7 is peak.
+ */
+export type Volume = number;
+
+/** Inclusive min volume. `VOLUME_MIN` is silent; `VOLUME_MAX` is peak. */
+export const VOLUME_MIN = 0;
+/** Inclusive max volume. */
+export const VOLUME_MAX = 7;
+
+/**
+ * Waveform slot. `0..7` are the built-in instruments (triangle, tilted
+ * saw, saw, square, pulse, organ, noise, phaser); `8..15` are reserved
+ * for user-defined custom instruments. Populated with names in
+ * `instruments.ts` (issue #6).
+ */
+export type InstrumentId = number;
+
+/** Inclusive min instrument slot. */
+export const INSTRUMENT_MIN = 0;
+/** Inclusive max instrument slot. Slots 0-7 are built-ins, 8-15 custom. */
+export const INSTRUMENT_MAX = 15;
+/** Inclusive max built-in instrument slot. */
+export const INSTRUMENT_BUILTIN_MAX = 7;
+
+/**
+ * Per-step effect column: `0` none, `1` slide, `2` vibrato, `3` drop,
+ * `4` fade in, `5` fade out, `6` arp fast, `7` arp slow. Fleshed out
+ * with names in `effects.ts` (issue #7).
+ */
+export type EffectId = number;
+
+/** Inclusive min effect id. */
+export const EFFECT_MIN = 0;
+/** Inclusive max effect id. */
+export const EFFECT_MAX = 7;
+
+/**
+ * Playback speed in ticks per step. Valid range is `1..255` — lower
+ * is faster, higher is slower.
+ */
+export type Speed = number;
+
+/** Inclusive min speed. */
+export const SPEED_MIN = 1;
+/** Inclusive max speed. */
+export const SPEED_MAX = 255;
+
+/**
+ * A single playable note on an SFX step — pitch, instrument, volume,
+ * and effect column.
+ */
+export interface Note {
+  readonly kind: 'note';
+  readonly pitch: Pitch;
+  readonly instrument: InstrumentId;
+  readonly volume: Volume;
+  readonly effect: EffectId;
+}
+
+/** Silent step — no pitch fires on this tick. */
+export interface Rest {
+  readonly kind: 'rest';
+}
+
+/** One slot in an SFX: either a note or a rest. */
+export type SfxStep = Note | Rest;
+
+/** Number of steps in every SFX. PICO-8 fixes this at 32. */
+export const STEPS_PER_SFX = 32;
+
+/**
+ * A complete SFX — 32 steps plus a speed (ticks per step). The
+ * `steps.length === STEPS_PER_SFX` invariant is enforced by the
+ * adapter layer at render time, not the type.
+ */
+export interface Sfx {
+  readonly steps: readonly SfxStep[];
+  readonly speed: Speed;
+}
+
+/** A music-pattern slot that plays a concrete Sfx. */
+export interface SfxChannel {
+  readonly kind: 'sfx';
+  readonly sfx: Sfx;
+}
+
+/** A music-pattern slot that stays silent. */
+export interface SilenceChannel {
+  readonly kind: 'silence';
+}
+
+/** One playing slot in a music pattern — either an SFX or silence. */
+export type MusicChannel = SfxChannel | SilenceChannel;
+
+/** Number of concurrent music channels PICO-8 supports. */
+export const MUSIC_CHANNELS_MAX = 4;
+
+/**
+ * A slice of music — up to `MUSIC_CHANNELS_MAX` channels playing in
+ * parallel. The `channels.length <= MUSIC_CHANNELS_MAX` invariant is
+ * enforced by the adapter layer at render time.
+ */
+export interface MusicPattern {
+  readonly channels: readonly MusicChannel[];
+}
+
+/**
+ * Optional loop markers on a Song. `start` and `end` are zero-based,
+ * **both inclusive**, indices into the song's `patterns` array. Once
+ * the scheduler finishes playing the pattern at `end`, the next cycle
+ * resumes at `start` and repeats until stopped.
+ *
+ * Invariant (enforced by `.loop()` in #10): `0 <= start <= end < patterns.length`.
+ */
+export interface LoopRange {
+  readonly start: number;
+  readonly end: number;
+}
+
+/**
+ * A chain of music patterns played in sequence. `loop` is optional —
+ * without it the song plays once and ends.
+ */
+export interface Song {
+  readonly patterns: readonly MusicPattern[];
+  readonly loop?: LoopRange;
+}


### PR DESCRIPTION
## Summary

Defines the PICO-8 layer's public type surface. Narrows the general pattern algebra to PICO-8 tracker semantics via tagged unions and range-aliased number types.

### Types

- **`Note`** `{ kind: 'note', pitch, instrument, volume, effect }`
- **`Rest`** `{ kind: 'rest' }` — the silent SFX step
- **`SfxStep`** = `Note | Rest`
- **`Sfx`** `{ steps, speed }` — 32 steps at a ticks-per-step cadence
- **`SfxChannel`** / **`SilenceChannel`** — two named variants that make `MusicChannel` symmetric with `Note`/`Rest`
- **`MusicChannel`** = `SfxChannel | SilenceChannel`
- **`MusicPattern`** `{ channels }` — up to `MUSIC_CHANNELS_MAX` concurrent channels
- **`LoopRange`** `{ start, end }` — both inclusive; invariant `0 <= start <= end < patterns.length`
- **`Song`** `{ patterns, loop? }` — optional loop means the song plays once and ends without one

### Numeric aliases + range constants

`Pitch` (0–63), `Volume` (0–7), `InstrumentId` (0–15; slots 0–7 built-in, 8–15 custom), `EffectId` (0–7), `Speed` (1–255). Each alias is backed by `*_MIN` / `*_MAX` constants so adapter-layer validation has a single source of truth.

### Design notes

- **Tagged unions with `kind` discriminants** over sentinels (`null`) or branded primitives — they round-trip cleanly to JSON for the future `.p8` serializer (#11) and print adapter (#14) and give pattern-matching ergonomics.
- **Array-over-tuple** for `Sfx.steps` and `MusicPattern.channels`. The `length === 32` and `length <= 4` invariants are validated at the adapter boundary rather than encoded in gigantic tuple types — per CLAUDE.md, runtime validation lives with the adapter.
- **Non-branded numeric aliases.** `Pitch` and `Volume` are both `number` at the type level. Branding would add construction friction with no payoff until a validation layer consumes these. Can be introduced later as a purely additive change.

Closes #5.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` — 77 tests, every type exercised via construction + discrimination
- [x] `bun run test:cov` — 100/98.14/100/100 (only unreached line is the defensive `gcd(0, 0)` in `time.ts`)
- [x] Changeset `.changeset/pico8-types.md` — minor bump on `loom`

## Review loop
Self-review flagged 4 items (VOLUME typo, loop inclusivity + invariant, missing `*_MIN` constants, inconsistent `MusicChannel` variant naming). All applied via autosquashed fixup. LGTM at round 2.