### PR TITLE
feat(pico8): implement the 8 built-in waveform instruments

### DIFF
--- a/.changeset/pico8-instruments.md
+++ b/.changeset/pico8-instruments.md
@@ -1,0 +1,10 @@
+---
+"loom": minor
+---
+
+**pico8:** ship the 8 built-in waveform instruments (triangle, tilted-saw, saw, square, pulse, organ, noise, phaser) at slots 0-7. New exports from `@loom/pico8`:
+
+- `BUILTIN_INSTRUMENTS: readonly BuiltinInstrument[]` — the canonical table, ordered by slot id.
+- `InstrumentName` — kebab-case string-literal union of the 8 names, consumable by the chainable setters in #8.
+- `instrumentIdFromName(name)` / `instrumentNameFromId(id)` — bidirectional name ↔ id lookups.
+- `isBuiltin(id)` — classifies a slot as built-in (0-7) vs custom (8-15).

--- a/src/pico8/index.ts
+++ b/src/pico8/index.ts
@@ -1,4 +1,12 @@
 export {
+  BUILTIN_INSTRUMENTS,
+  type BuiltinInstrument,
+  instrumentIdFromName,
+  type InstrumentName,
+  instrumentNameFromId,
+  isBuiltin,
+} from '@loom/pico8/instruments.js';
+export {
   EFFECT_MAX,
   EFFECT_MIN,
   type EffectId,

--- a/src/pico8/instruments.test.ts
+++ b/src/pico8/instruments.test.ts
@@ -1,0 +1,90 @@
+import {
+  BUILTIN_INSTRUMENTS,
+  instrumentIdFromName,
+  type InstrumentName,
+  instrumentNameFromId,
+  isBuiltin,
+} from '@loom/pico8/instruments.js';
+import { describe, expect, it } from 'vitest';
+
+describe('pico8/instruments', () => {
+  describe('BUILTIN_INSTRUMENTS', () => {
+    it('lists the 8 PICO-8 waveforms in slot order', () => {
+      const expected: readonly InstrumentName[] = [
+        'triangle',
+        'tilted-saw',
+        'saw',
+        'square',
+        'pulse',
+        'organ',
+        'noise',
+        'phaser',
+      ];
+      expect(BUILTIN_INSTRUMENTS.map((i) => i.name)).toEqual(expected);
+    });
+
+    it('assigns consecutive ids 0-7', () => {
+      expect(BUILTIN_INSTRUMENTS.map((i) => i.id)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+    });
+
+    it('is readonly — the array is shaped as readonly', () => {
+      // Structural sanity: the exported type is `readonly BuiltinInstrument[]`
+      // so `.push` on a consumer-facing binding is a compile-time error.
+      // We verify the contents haven't drifted at runtime.
+      expect(BUILTIN_INSTRUMENTS).toHaveLength(8);
+    });
+  });
+
+  describe('isBuiltin', () => {
+    it('returns true for slots 0-7', () => {
+      for (let id = 0; id <= 7; id++) {
+        expect(isBuiltin(id)).toBe(true);
+      }
+    });
+
+    it('returns false for custom slots 8-15', () => {
+      for (let id = 8; id <= 15; id++) {
+        expect(isBuiltin(id)).toBe(false);
+      }
+    });
+
+    it('returns false for out-of-range and non-integer ids', () => {
+      expect(isBuiltin(-1)).toBe(false);
+      expect(isBuiltin(16)).toBe(false);
+      expect(isBuiltin(3.5)).toBe(false);
+      expect(isBuiltin(Number.NaN)).toBe(false);
+    });
+  });
+
+  describe('instrumentIdFromName', () => {
+    it('resolves each built-in name to its slot', () => {
+      expect(instrumentIdFromName('triangle')).toBe(0);
+      expect(instrumentIdFromName('tilted-saw')).toBe(1);
+      expect(instrumentIdFromName('saw')).toBe(2);
+      expect(instrumentIdFromName('square')).toBe(3);
+      expect(instrumentIdFromName('pulse')).toBe(4);
+      expect(instrumentIdFromName('organ')).toBe(5);
+      expect(instrumentIdFromName('noise')).toBe(6);
+      expect(instrumentIdFromName('phaser')).toBe(7);
+    });
+  });
+
+  describe('instrumentNameFromId', () => {
+    it('round-trips each built-in id to its name', () => {
+      for (const { id, name } of BUILTIN_INSTRUMENTS) {
+        expect(instrumentNameFromId(id)).toBe(name);
+      }
+    });
+
+    it('returns undefined for custom slots 8-15', () => {
+      for (let id = 8; id <= 15; id++) {
+        expect(instrumentNameFromId(id)).toBeUndefined();
+      }
+    });
+
+    it('returns undefined for out-of-range ids', () => {
+      expect(instrumentNameFromId(-1)).toBeUndefined();
+      expect(instrumentNameFromId(16)).toBeUndefined();
+    });
+  });
+});

--- a/src/pico8/instruments.ts
+++ b/src/pico8/instruments.ts
@@ -1,0 +1,81 @@
+import { INSTRUMENT_BUILTIN_MAX, INSTRUMENT_MIN, type InstrumentId } from '@loom/pico8/types.js';
+
+/**
+ * Kebab-case names for the 8 built-in PICO-8 waveforms, ordered by
+ * their slot id. Exported as a union so chainable setters in #8 can
+ * accept either a numeric id or the name.
+ */
+export type InstrumentName =
+  | 'triangle'
+  | 'tilted-saw'
+  | 'saw'
+  | 'square'
+  | 'pulse'
+  | 'organ'
+  | 'noise'
+  | 'phaser';
+
+/** An entry in the built-in instrument table. */
+export interface BuiltinInstrument {
+  readonly id: InstrumentId;
+  readonly name: InstrumentName;
+}
+
+/**
+ * The 8 built-in PICO-8 waveforms, ordered so `BUILTIN_INSTRUMENTS[id]`
+ * yields the matching entry for slots 0-7. Slots 8-15 are reserved
+ * for user-defined custom instruments and live outside this table.
+ */
+export const BUILTIN_INSTRUMENTS: readonly BuiltinInstrument[] = [
+  { id: 0, name: 'triangle' },
+  { id: 1, name: 'tilted-saw' },
+  { id: 2, name: 'saw' },
+  { id: 3, name: 'square' },
+  { id: 4, name: 'pulse' },
+  { id: 5, name: 'organ' },
+  { id: 6, name: 'noise' },
+  { id: 7, name: 'phaser' },
+];
+
+/**
+ * Name → id lookup for the 8 built-ins. Kept in sync with
+ * `BUILTIN_INSTRUMENTS` at module load so consumers never need to
+ * scan the array.
+ */
+const ID_BY_NAME: ReadonlyMap<InstrumentName, InstrumentId> = new Map(
+  BUILTIN_INSTRUMENTS.map(({ id, name }) => [name, id]),
+);
+
+/**
+ * Whether `id` refers to a built-in waveform slot (0-7). Slots 8-15
+ * point at user-defined custom instruments and return `false`.
+ *
+ * @param id - Instrument slot to classify
+ * @returns `true` if `id` is a built-in slot, `false` otherwise
+ */
+export function isBuiltin(id: InstrumentId): boolean {
+  return Number.isInteger(id) && id >= INSTRUMENT_MIN && id <= INSTRUMENT_BUILTIN_MAX;
+}
+
+/**
+ * Resolves a built-in waveform name to its slot id.
+ *
+ * @param name - Kebab-case built-in waveform name
+ * @returns The matching `InstrumentId` (0-7)
+ */
+export function instrumentIdFromName(name: InstrumentName): InstrumentId {
+  // The Map is built from the exact same name union at module load —
+  // `name` is guaranteed to be a key, so the lookup cannot miss.
+  return ID_BY_NAME.get(name) as InstrumentId;
+}
+
+/**
+ * Resolves a built-in slot id to its canonical name, or `undefined`
+ * for custom (non-built-in) slots.
+ *
+ * @param id - Built-in instrument slot (0-7)
+ * @returns The matching name, or `undefined` if `id` is not a built-in
+ */
+export function instrumentNameFromId(id: InstrumentId): InstrumentName | undefined {
+  return isBuiltin(id) ? BUILTIN_INSTRUMENTS[id]?.name : undefined;
+}


### PR DESCRIPTION
## Summary

Populates slots 0–7 of the `InstrumentId` (0..15) range with the canonical PICO-8 waveforms and ships the bidirectional name↔id lookups needed by the chainable setters (#8) and the future `.p8` serializer (#11).

### New exports from `@loom/pico8`

- **`BUILTIN_INSTRUMENTS: readonly BuiltinInstrument[]`** — canonical table, ordered by slot id (`[triangle, tilted-saw, saw, square, pulse, organ, noise, phaser]`).
- **`InstrumentName`** — kebab-case string-literal union matching issue #8's setter signature verbatim.
- **`isBuiltin(id)`** — classifies a slot as built-in (0–7) vs custom (8–15). Handles non-integer / NaN / OOB safely via `Number.isInteger` + range check.
- **`instrumentIdFromName(name)`** / **`instrumentNameFromId(id)`** — bidirectional lookups. Name→id assumes the compile-time `InstrumentName` guard (runtime string validation is #8's boundary concern); id→name returns `undefined` for non-built-in slots.

### Design notes

- The name union is hand-written alongside the array. Adding a name to the array without adding it to the union triggers a TS error; the reverse direction (union without array) isn't caught by TS — keeping the maintenance surface tight. Acceptable for 8 stable waveforms.
- `instrumentIdFromName` is narrow: it takes `InstrumentName`, not `InstrumentId | InstrumentName`. The `.inst(x)` setter in #8 dispatches between the two; this module stays focused.

Closes #6.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` — 87 tests, every helper path exercised (isBuiltin for 0, 7, 8, 15, -1, 16, 3.5, NaN; round-trip on all 8 built-ins; custom-slot falls through to undefined)
- [x] `bun run test:cov` — 100/98.3/100/100

## Review loop
Self-review LGTM at round 1.