### PR TITLE
feat(pico8): implement the 8 per-step effects

### DIFF
--- a/.changeset/pico8-effects.md
+++ b/.changeset/pico8-effects.md
@@ -1,0 +1,11 @@
+---
+"loom": minor
+---
+
+**pico8:** ship the 8 per-step effects (none, slide, vibrato, drop, fade-in, fade-out, arp-fast, arp-slow) at slots 0-7. New exports from `@loom/pico8`:
+
+- `EFFECTS: readonly Effect[]` — canonical table, ordered by slot id.
+- `EffectName` — kebab-case string-literal union of the 8 names, consumable by the chainable `.fx()` setter in #8.
+- `effectIdFromName(name)` / `effectNameFromId(id)` — bidirectional name ↔ id lookups.
+
+Audio semantics are implemented by adapters (e.g. the Web Audio synth in #15). This module only names the slots.

--- a/src/pico8/effects.test.ts
+++ b/src/pico8/effects.test.ts
@@ -1,0 +1,59 @@
+import {
+  effectIdFromName,
+  type EffectName,
+  effectNameFromId,
+  EFFECTS,
+} from '@loom/pico8/effects.js';
+import { describe, expect, it } from 'vitest';
+
+describe('pico8/effects', () => {
+  describe('EFFECTS', () => {
+    it('lists the 8 PICO-8 effects in slot order', () => {
+      const expected: readonly EffectName[] = [
+        'none',
+        'slide',
+        'vibrato',
+        'drop',
+        'fade-in',
+        'fade-out',
+        'arp-fast',
+        'arp-slow',
+      ];
+      expect(EFFECTS.map((e) => e.name)).toEqual(expected);
+    });
+
+    it('assigns consecutive ids 0-7', () => {
+      expect(EFFECTS.map((e) => e.id)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+    });
+
+    it('is length 8', () => {
+      expect(EFFECTS).toHaveLength(8);
+    });
+  });
+
+  describe('effectIdFromName', () => {
+    it('resolves each name to its slot', () => {
+      expect(effectIdFromName('none')).toBe(0);
+      expect(effectIdFromName('slide')).toBe(1);
+      expect(effectIdFromName('vibrato')).toBe(2);
+      expect(effectIdFromName('drop')).toBe(3);
+      expect(effectIdFromName('fade-in')).toBe(4);
+      expect(effectIdFromName('fade-out')).toBe(5);
+      expect(effectIdFromName('arp-fast')).toBe(6);
+      expect(effectIdFromName('arp-slow')).toBe(7);
+    });
+  });
+
+  describe('effectNameFromId', () => {
+    it('round-trips each id to its name', () => {
+      for (const { id, name } of EFFECTS) {
+        expect(effectNameFromId(id)).toBe(name);
+      }
+    });
+
+    it('returns undefined for out-of-range ids', () => {
+      expect(effectNameFromId(-1)).toBeUndefined();
+      expect(effectNameFromId(8)).toBeUndefined();
+    });
+  });
+});

--- a/src/pico8/effects.ts
+++ b/src/pico8/effects.ts
@@ -1,0 +1,69 @@
+import type { EffectId } from '@loom/pico8/types.js';
+
+/**
+ * Kebab-case names for the 8 per-step effect columns, ordered by
+ * their slot id. Exported as a union so chainable setters in #8 can
+ * accept either a numeric id or the name.
+ */
+export type EffectName =
+  | 'none'
+  | 'slide'
+  | 'vibrato'
+  | 'drop'
+  | 'fade-in'
+  | 'fade-out'
+  | 'arp-fast'
+  | 'arp-slow';
+
+/** An entry in the effects table. */
+export interface Effect {
+  readonly id: EffectId;
+  readonly name: EffectName;
+}
+
+/**
+ * The 8 PICO-8 per-step effects, ordered so `EFFECTS[id]` yields the
+ * matching entry. Audio semantics are implemented by adapters; this
+ * table only names the slots.
+ */
+export const EFFECTS: readonly Effect[] = [
+  { id: 0, name: 'none' },
+  { id: 1, name: 'slide' },
+  { id: 2, name: 'vibrato' },
+  { id: 3, name: 'drop' },
+  { id: 4, name: 'fade-in' },
+  { id: 5, name: 'fade-out' },
+  { id: 6, name: 'arp-fast' },
+  { id: 7, name: 'arp-slow' },
+];
+
+/**
+ * Name → id lookup for the 8 effects. Kept in sync with `EFFECTS`
+ * at module load so consumers never need to scan the array.
+ */
+const ID_BY_NAME: ReadonlyMap<EffectName, EffectId> = new Map(
+  EFFECTS.map(({ id, name }) => [name, id]),
+);
+
+/**
+ * Resolves an effect name to its slot id.
+ *
+ * @param name - Kebab-case effect name
+ * @returns The matching `EffectId` (0-7)
+ */
+export function effectIdFromName(name: EffectName): EffectId {
+  // The Map is built from the exact same name union at module load —
+  // `name` is guaranteed to be a key, so the lookup cannot miss.
+  return ID_BY_NAME.get(name) as EffectId;
+}
+
+/**
+ * Resolves an effect slot id to its canonical name, or `undefined`
+ * for out-of-range ids.
+ *
+ * @param id - Effect slot (0-7)
+ * @returns The matching name, or `undefined` if `id` is out of range
+ */
+export function effectNameFromId(id: EffectId): EffectName | undefined {
+  return EFFECTS[id]?.name;
+}

--- a/src/pico8/index.ts
+++ b/src/pico8/index.ts
@@ -1,4 +1,11 @@
 export {
+  type Effect,
+  effectIdFromName,
+  type EffectName,
+  effectNameFromId,
+  EFFECTS,
+} from '@loom/pico8/effects.js';
+export {
   BUILTIN_INSTRUMENTS,
   type BuiltinInstrument,
   instrumentIdFromName,


### PR DESCRIPTION
## Summary

Populates the effect-column slots 0–7 with the canonical PICO-8 effects. Mirrors the `pico8/instruments` shape for a uniform lookup surface.

### New exports from `@loom/pico8`

- **`EFFECTS: readonly Effect[]`** — canonical table, ordered by slot id (`[none, slide, vibrato, drop, fade-in, fade-out, arp-fast, arp-slow]`).
- **`EffectName`** — kebab-case string-literal union matching issue #8's `.fx(x)` setter signature verbatim.
- **`effectIdFromName(name)`** / **`effectNameFromId(id)`** — bidirectional lookups.

### Design notes

- **No `isBuiltin` equivalent.** Effects are a single 0–7 range with no custom-slot split, so there's no classification to perform.
- **Audio is a concern for adapters** (e.g. the Web Audio synth in #15). This module only names the slots.
- **Parity with `instruments.ts`** is deliberate: same shape, same JSDoc phrasing, same `as EffectId` cast with the same rationale comment. Consumers get a consistent mental model when reading either file.

Closes #7.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` — 93 tests across core + pico8
- [x] `bun run test:cov` — 100/98.3/100/100
- [x] Changeset — minor bump on `loom`

## Review loop
Self-review LGTM at round 1.