### PR TITLE
feat(pico8): chainable attribute setters on Pattern

### DIFF
--- a/.changeset/pico8-chainable-setters.md
+++ b/.changeset/pico8-chainable-setters.md
@@ -1,0 +1,20 @@
+---
+"loom": minor
+---
+
+**pico8:** ship the Strudel-style chainable attribute setters for every `Pattern<T>`. Importing `@loom/pico8` augments `Pattern.prototype` with:
+
+- `.inst(x)` / `.instrument(x)` — waveform slot (0-15, built-in name, or `Pattern<InstrumentId>`)
+- `.vol(n)` / `.volume(n)` — volume (0-7 or `Pattern<Volume>`)
+- `.fx(x)` / `.effect(x)` — effect (0-7, kebab-case name, or `Pattern<EffectId>`)
+- `.ch(n)` / `.channel(n)` — music channel (0-3, enforced at the type level)
+- `.speed(n)` — ticks per step (1-255)
+
+Each setter returns a new `Pattern` with the attribute merged into every event's value. Primitive values apply uniformly; `Pattern` values "zip" — the value pattern's events structure which base events survive.
+
+Invalid string names throw `Pico8Error` with codes `PICO8_UNKNOWN_INSTRUMENT` / `PICO8_UNKNOWN_EFFECT`. Also newly exported:
+
+- `Pico8Error` / `Pico8ErrorCode` — stable error-code hierarchy for the PICO-8 layer
+- `ChannelIndex` / `Pico8Attributes` — the attribute-bearing shape consumed by adapters
+
+Range validation for `Volume`, `Pitch`, `Speed` is deferred to adapters — this module only sets attributes.

--- a/src/pico8/attributes.ts
+++ b/src/pico8/attributes.ts
@@ -1,0 +1,24 @@
+import type { EffectId, InstrumentId, Pitch, Speed, Volume } from '@loom/pico8/types.js';
+
+/** PICO-8 music channel index. 0-3; anything else fails at adapter time. */
+export type ChannelIndex = 0 | 1 | 2 | 3;
+
+/**
+ * Attributes a Pattern can carry toward the PICO-8 adapter. Every
+ * field is optional — the adapter fills in defaults (volume 5,
+ * instrument 0, effect 0, channel 0) when a field is missing.
+ *
+ * Adapter-facing shape. The chainable setters in `augment.ts` do NOT
+ * return `Pattern<Pico8Attributes>` — they produce per-key
+ * intersections (`T & { inst: InstrumentId }`, etc.) so each chain
+ * step preserves the incremental type, and the rendered shape
+ * converges on `Pico8Attributes` at adapter time.
+ */
+export interface Pico8Attributes {
+  readonly pitch?: Pitch;
+  readonly inst?: InstrumentId;
+  readonly vol?: Volume;
+  readonly fx?: EffectId;
+  readonly ch?: ChannelIndex;
+  readonly speed?: Speed;
+}

--- a/src/pico8/augment.test.ts
+++ b/src/pico8/augment.test.ts
@@ -1,0 +1,222 @@
+// Side-effect import: attaches the chainable setters onto Pattern.prototype.
+import '@loom/pico8/augment.js';
+
+import { Pattern } from '@loom/core/pattern.js';
+import { pure, seq } from '@loom/core/primitives.js';
+import { Time } from '@loom/core/time.js';
+import { EFFECTS } from '@loom/pico8/effects.js';
+import { Pico8Error } from '@loom/pico8/errors.js';
+import { BUILTIN_INSTRUMENTS } from '@loom/pico8/instruments.js';
+import { describe, expect, it } from 'vitest';
+
+describe('pico8/augment — chainable setters', () => {
+  describe('inst / instrument', () => {
+    it('accepts a numeric slot and attaches inst to every event', () => {
+      const events = pure({ pitch: 48 }).inst(3).query(Time.ZERO, Time.ONE);
+      expect(events[0]?.value).toEqual({ pitch: 48, inst: 3 });
+    });
+
+    it('resolves a built-in name to its slot', () => {
+      const events = pure({ pitch: 48 }).inst('triangle').query(Time.ZERO, Time.ONE);
+      expect(events[0]?.value).toEqual({ pitch: 48, inst: 0 });
+    });
+
+    it('throws PICO8_UNKNOWN_INSTRUMENT on an invalid name', () => {
+      try {
+        pure({ pitch: 48 }).inst('wobble' as 'triangle');
+        expect.fail('expected throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(Pico8Error);
+        expect((error as Pico8Error).code).toBe('PICO8_UNKNOWN_INSTRUMENT');
+      }
+    });
+
+    it('zips a Pattern value per step', () => {
+      // seq(pure(0), pure(5)) fires 0 on [0, 1/2) and 5 on [1/2, 1).
+      // Run two pure notes over those halves via seq of pure notes.
+      const notes = pure({ pitch: 48 });
+      const ids = pure(7 as const); // constant id everywhere
+      const events = notes.inst(ids).query(Time.ZERO, Time.ONE);
+      expect(events[0]?.value).toEqual({ pitch: 48, inst: 7 });
+    });
+
+    it('long alias .instrument is the same method', () => {
+      const events = pure({ pitch: 48 }).instrument('square').query(Time.ZERO, Time.ONE);
+      expect(events[0]?.value).toEqual({ pitch: 48, inst: 3 });
+    });
+
+    it('resolves every built-in instrument name through the setter', () => {
+      // Guards against drift between the BUILTIN_INSTRUMENTS table
+      // and the InstrumentName union consumed by .inst().
+      for (const { id, name } of BUILTIN_INSTRUMENTS) {
+        const events = pure({ pitch: 48 }).inst(name).query(Time.ZERO, Time.ONE);
+        expect(events[0]?.value).toEqual({ pitch: 48, inst: id });
+      }
+    });
+  });
+
+  describe('vol / volume', () => {
+    it('accepts a constant', () => {
+      const events = pure({ pitch: 48 }).vol(5).query(Time.ZERO, Time.ONE);
+      expect(events[0]?.value).toEqual({ pitch: 48, vol: 5 });
+    });
+
+    it('accepts a Pattern value', () => {
+      const events = pure({ pitch: 48 }).vol(pure(3)).query(Time.ZERO, Time.ONE);
+      expect(events[0]?.value).toEqual({ pitch: 48, vol: 3 });
+    });
+
+    it('long alias .volume', () => {
+      const events = pure({ pitch: 48 }).volume(7).query(Time.ZERO, Time.ONE);
+      expect(events[0]?.value).toEqual({ pitch: 48, vol: 7 });
+    });
+  });
+
+  describe('fx / effect', () => {
+    it('accepts a numeric effect id', () => {
+      const events = pure({ pitch: 48 }).fx(2).query(Time.ZERO, Time.ONE);
+      expect(events[0]?.value).toEqual({ pitch: 48, fx: 2 });
+    });
+
+    it('resolves a kebab-case effect name', () => {
+      const events = pure({ pitch: 48 }).fx('fade-in').query(Time.ZERO, Time.ONE);
+      expect(events[0]?.value).toEqual({ pitch: 48, fx: 4 });
+    });
+
+    it('throws PICO8_UNKNOWN_EFFECT on an invalid name', () => {
+      try {
+        pure({ pitch: 48 }).fx('wobble' as 'slide');
+        expect.fail('expected throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(Pico8Error);
+        expect((error as Pico8Error).code).toBe('PICO8_UNKNOWN_EFFECT');
+      }
+    });
+
+    it('accepts a Pattern value', () => {
+      const events = pure({ pitch: 48 }).fx(pure(6)).query(Time.ZERO, Time.ONE);
+      expect(events[0]?.value).toEqual({ pitch: 48, fx: 6 });
+    });
+
+    it('long alias .effect', () => {
+      const events = pure({ pitch: 48 }).effect('vibrato').query(Time.ZERO, Time.ONE);
+      expect(events[0]?.value).toEqual({ pitch: 48, fx: 2 });
+    });
+
+    it('resolves every effect name through the setter', () => {
+      // Guards against drift between the EFFECTS table and the
+      // EffectName union consumed by .fx().
+      for (const { id, name } of EFFECTS) {
+        const events = pure({ pitch: 48 }).fx(name).query(Time.ZERO, Time.ONE);
+        expect(events[0]?.value).toEqual({ pitch: 48, fx: id });
+      }
+    });
+  });
+
+  describe('ch / channel', () => {
+    it('attaches the channel to every event', () => {
+      const events = pure({ pitch: 48 }).ch(2).query(Time.ZERO, Time.ONE);
+      expect(events[0]?.value).toEqual({ pitch: 48, ch: 2 });
+    });
+
+    it('long alias .channel', () => {
+      const events = pure({ pitch: 48 }).channel(0).query(Time.ZERO, Time.ONE);
+      expect(events[0]?.value).toEqual({ pitch: 48, ch: 0 });
+    });
+  });
+
+  describe('speed', () => {
+    it('attaches the speed to every event', () => {
+      const events = pure({ pitch: 48 }).speed(16).query(Time.ZERO, Time.ONE);
+      expect(events[0]?.value).toEqual({ pitch: 48, speed: 16 });
+    });
+  });
+
+  describe('chaining', () => {
+    it('composes all setters into a single event value', () => {
+      const events = pure({ pitch: 48 })
+        .inst('triangle')
+        .vol(5)
+        .fx('slide')
+        .ch(0)
+        .speed(16)
+        .query(Time.ZERO, Time.ONE);
+      expect(events[0]?.value).toEqual({
+        pitch: 48,
+        inst: 0,
+        vol: 5,
+        fx: 1,
+        ch: 0,
+        speed: 16,
+      });
+    });
+
+    it('later setters overwrite earlier ones on the same key', () => {
+      const events = pure({ pitch: 48 }).vol(2).vol(7).query(Time.ZERO, Time.ONE);
+      expect(events[0]?.value).toEqual({ pitch: 48, vol: 7 });
+    });
+
+    it('each setter returns a new Pattern — the source is unchanged', () => {
+      const base = pure({ pitch: 48 });
+      const attached = base.vol(5);
+      expect(base.query(Time.ZERO, Time.ONE)[0]?.value).toEqual({ pitch: 48 });
+      expect(attached.query(Time.ZERO, Time.ONE)[0]?.value).toEqual({ pitch: 48, vol: 5 });
+    });
+  });
+
+  describe('pattern-value zipping', () => {
+    it('drops base events that have no value active at their begin', () => {
+      const notes = pure({ pitch: 48 });
+      const empty = new Pattern<number>(() => []);
+      const events = notes.vol(empty).query(Time.ZERO, Time.ONE);
+      expect(events).toEqual([]);
+    });
+
+    it('returns nothing when the base pattern is empty (constant value path)', () => {
+      const empty = new Pattern<{ pitch: number }>(() => []);
+      const events = empty.vol(5).query(Time.ZERO, Time.ONE);
+      expect(events).toEqual([]);
+    });
+
+    it('returns nothing when the base pattern is empty (pattern-value path)', () => {
+      const empty = new Pattern<{ pitch: number }>(() => []);
+      const values = pure(5);
+      const events = empty.vol(values).query(Time.ZERO, Time.ONE);
+      expect(events).toEqual([]);
+    });
+
+    it('zips per-step varying values into per-step varying notes', () => {
+      // Four notes across a cycle with four varying volumes at the
+      // same grid — the Strudel-style `.vol(mini('5 3 7 2'))` case.
+      const notes = seq(
+        pure({ pitch: 48 }),
+        pure({ pitch: 52 }),
+        pure({ pitch: 55 }),
+        pure({ pitch: 60 }),
+      );
+      const vols = seq(pure(5), pure(3), pure(7), pure(2));
+      const events = notes.vol(vols).query(Time.ZERO, Time.ONE);
+      expect(events.map((e) => e.value)).toEqual([
+        { pitch: 48, vol: 5 },
+        { pitch: 52, vol: 3 },
+        { pitch: 55, vol: 7 },
+        { pitch: 60, vol: 2 },
+      ]);
+    });
+
+    it('extends the value-query window to cover base events that overflow end', () => {
+      // A base event that spans [0, 2) — ends past the query window [0, 1).
+      const tail = new Pattern<{ pitch: number }>(() => [
+        { begin: Time.ZERO, end: new Time(2n, 1n), value: { pitch: 48 } },
+      ]);
+      // Value pattern is defined only over [1, 2), so the base event's
+      // begin (=0) must be looked up there — it won't match and the
+      // event is dropped. This exercises the maxEnd extension path.
+      const values = new Pattern<number>(() => [
+        { begin: Time.ONE, end: new Time(2n, 1n), value: 7 },
+      ]);
+      const events = tail.vol(values).query(Time.ZERO, Time.ONE);
+      expect(events).toEqual([]);
+    });
+  });
+});

--- a/src/pico8/augment.ts
+++ b/src/pico8/augment.ts
@@ -1,0 +1,242 @@
+import type { Event } from '@loom/core/event.js';
+import { Pattern } from '@loom/core/pattern.js';
+import type { Time } from '@loom/core/time.js';
+import type { ChannelIndex } from '@loom/pico8/attributes.js';
+import { effectIdFromName, type EffectName, EFFECTS } from '@loom/pico8/effects.js';
+import { Pico8Error } from '@loom/pico8/errors.js';
+import {
+  BUILTIN_INSTRUMENTS,
+  instrumentIdFromName,
+  type InstrumentName,
+} from '@loom/pico8/instruments.js';
+import type { EffectId, InstrumentId, Speed, Volume } from '@loom/pico8/types.js';
+
+declare module '@loom/core/pattern.js' {
+  // The `this: Pattern<T & object>` constraint on every setter rules
+  // out calls on a Pattern of primitives. Spreading a primitive to
+  // merge attributes silently discards it (`{...48}` is `{}`), which
+  // would be a footgun — every setter requires an object-shaped value.
+  // If T is already object-like, `T & object` is T; if T is a
+  // primitive or `never`, `T & object` collapses to `never` and the
+  // receiver type rejects the call at compile time.
+  interface Pattern<T> {
+    /**
+     * Sets the PICO-8 waveform/instrument for every event. Accepts a
+     * numeric slot id (0-15), a built-in name (`'triangle'`, ...), or
+     * a `Pattern<InstrumentId>` that zips per step.
+     *
+     * Invalid string names throw `Pico8Error('PICO8_UNKNOWN_INSTRUMENT')`.
+     */
+    inst(
+      this: Pattern<T & object>,
+      value: InstrumentId | InstrumentName | Pattern<InstrumentId>,
+    ): Pattern<T & { inst: InstrumentId }>;
+    /** Long alias for {@link Pattern.inst}. */
+    instrument(
+      this: Pattern<T & object>,
+      value: InstrumentId | InstrumentName | Pattern<InstrumentId>,
+    ): Pattern<T & { inst: InstrumentId }>;
+
+    /**
+     * Sets the volume (0-7) for every event. Accepts a number or a
+     * `Pattern<Volume>` that zips per step. Range validation happens
+     * at the adapter boundary.
+     */
+    vol(this: Pattern<T & object>, value: Volume | Pattern<Volume>): Pattern<T & { vol: Volume }>;
+    /** Long alias for {@link Pattern.vol}. */
+    volume(
+      this: Pattern<T & object>,
+      value: Volume | Pattern<Volume>,
+    ): Pattern<T & { vol: Volume }>;
+
+    /**
+     * Sets the per-step effect for every event. Accepts a numeric
+     * effect id (0-7), a kebab-case name (`'slide'`, `'fade-in'`, ...),
+     * or a `Pattern<EffectId>` that zips per step.
+     *
+     * Invalid string names throw `Pico8Error('PICO8_UNKNOWN_EFFECT')`.
+     */
+    fx(
+      this: Pattern<T & object>,
+      value: EffectId | EffectName | Pattern<EffectId>,
+    ): Pattern<T & { fx: EffectId }>;
+    /** Long alias for {@link Pattern.fx}. */
+    effect(
+      this: Pattern<T & object>,
+      value: EffectId | EffectName | Pattern<EffectId>,
+    ): Pattern<T & { fx: EffectId }>;
+
+    /**
+     * Assigns a PICO-8 music channel (0-3) to every event. Range is
+     * enforced at the type level since there are only four channels.
+     */
+    ch(this: Pattern<T & object>, value: ChannelIndex): Pattern<T & { ch: ChannelIndex }>;
+    /** Long alias for {@link Pattern.ch}. */
+    channel(this: Pattern<T & object>, value: ChannelIndex): Pattern<T & { ch: ChannelIndex }>;
+
+    /**
+     * Sets the SFX playback speed (1-255 ticks per step) for every
+     * event. Range validation happens at the adapter boundary.
+     */
+    speed(this: Pattern<T & object>, value: Speed): Pattern<T & { speed: Speed }>;
+  }
+}
+
+const BUILTIN_INSTRUMENT_NAMES: ReadonlySet<string> = new Set(
+  BUILTIN_INSTRUMENTS.map((i) => i.name),
+);
+const EFFECT_NAMES: ReadonlySet<string> = new Set(EFFECTS.map((e) => e.name));
+
+function isInstrumentName(value: unknown): value is InstrumentName {
+  return typeof value === 'string' && BUILTIN_INSTRUMENT_NAMES.has(value);
+}
+
+function isEffectName(value: unknown): value is EffectName {
+  return typeof value === 'string' && EFFECT_NAMES.has(value);
+}
+
+function resolveInstrument(value: InstrumentId | InstrumentName): InstrumentId {
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (!isInstrumentName(value)) {
+    throw new Pico8Error(
+      'PICO8_UNKNOWN_INSTRUMENT',
+      `Unknown instrument name: ${JSON.stringify(value)}`,
+    );
+  }
+  return instrumentIdFromName(value);
+}
+
+function resolveEffect(value: EffectId | EffectName): EffectId {
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (!isEffectName(value)) {
+    throw new Pico8Error('PICO8_UNKNOWN_EFFECT', `Unknown effect name: ${JSON.stringify(value)}`);
+  }
+  return effectIdFromName(value);
+}
+
+function isPattern<T>(value: unknown): value is Pattern<T> {
+  return value instanceof Pattern;
+}
+
+/**
+ * For each event in `base`, find a value active at the event's begin
+ * time and merge it into the event's value. Events with no value
+ * covering their begin instant are dropped — the value pattern
+ * "structures" which events survive.
+ */
+function zipPatternValue<A extends object, B, C extends object>(
+  base: Pattern<A>,
+  values: Pattern<B>,
+  merge: (eventValue: A, attrValue: B) => C,
+): Pattern<C> {
+  return new Pattern<C>((begin, end) => {
+    const baseEvents = base.query(begin, end);
+    if (baseEvents.length === 0) {
+      return [];
+    }
+    // Extend the value-query window to cover every base event's end.
+    let maxEnd: Time = end;
+    for (const event of baseEvents) {
+      if (event.end.gt(maxEnd)) {
+        maxEnd = event.end;
+      }
+    }
+    const valueEvents = values.query(begin, maxEnd);
+    return baseEvents.flatMap((event) => {
+      const active = valueEvents.find((ve) => ve.begin.lte(event.begin) && ve.end.gt(event.begin));
+      if (active === undefined) {
+        return [];
+      }
+      const next: Event<C> = {
+        begin: event.begin,
+        end: event.end,
+        value: merge(event.value, active.value),
+        ...(event.context === undefined ? {} : { context: event.context }),
+      };
+      return [next];
+    });
+  });
+}
+
+// The augment-time cast to a wide-open signature lets us ignore the
+// precise T in implementation; the declare-module block above is what
+// gives consumers their sharp types.
+type AnySetter = (value: unknown) => unknown;
+
+Pattern.prototype.inst = function inst<T extends object>(
+  this: Pattern<T>,
+  value: InstrumentId | InstrumentName | Pattern<InstrumentId>,
+): Pattern<T & { inst: InstrumentId }> {
+  if (isPattern<InstrumentId>(value)) {
+    return zipPatternValue(this, value, (v, id) => ({ ...v, inst: id }));
+  }
+  const id = resolveInstrument(value);
+  return this.map((v) => ({ ...v, inst: id }));
+} as AnySetter as Pattern<object>['inst'];
+
+Pattern.prototype.instrument = function instrument<T extends object>(
+  this: Pattern<T>,
+  value: InstrumentId | InstrumentName | Pattern<InstrumentId>,
+): Pattern<T & { inst: InstrumentId }> {
+  return this.inst(value);
+} as AnySetter as Pattern<object>['instrument'];
+
+Pattern.prototype.vol = function vol<T extends object>(
+  this: Pattern<T>,
+  value: Volume | Pattern<Volume>,
+): Pattern<T & { vol: Volume }> {
+  if (isPattern<Volume>(value)) {
+    return zipPatternValue(this, value, (v, n) => ({ ...v, vol: n }));
+  }
+  return this.map((v) => ({ ...v, vol: value }));
+} as AnySetter as Pattern<object>['vol'];
+
+Pattern.prototype.volume = function volume<T extends object>(
+  this: Pattern<T>,
+  value: Volume | Pattern<Volume>,
+): Pattern<T & { vol: Volume }> {
+  return this.vol(value);
+} as AnySetter as Pattern<object>['volume'];
+
+Pattern.prototype.fx = function fx<T extends object>(
+  this: Pattern<T>,
+  value: EffectId | EffectName | Pattern<EffectId>,
+): Pattern<T & { fx: EffectId }> {
+  if (isPattern<EffectId>(value)) {
+    return zipPatternValue(this, value, (v, id) => ({ ...v, fx: id }));
+  }
+  const id = resolveEffect(value);
+  return this.map((v) => ({ ...v, fx: id }));
+} as AnySetter as Pattern<object>['fx'];
+
+Pattern.prototype.effect = function effect<T extends object>(
+  this: Pattern<T>,
+  value: EffectId | EffectName | Pattern<EffectId>,
+): Pattern<T & { fx: EffectId }> {
+  return this.fx(value);
+} as AnySetter as Pattern<object>['effect'];
+
+Pattern.prototype.ch = function ch<T extends object>(
+  this: Pattern<T>,
+  value: ChannelIndex,
+): Pattern<T & { ch: ChannelIndex }> {
+  return this.map((v) => ({ ...v, ch: value }));
+} as AnySetter as Pattern<object>['ch'];
+
+Pattern.prototype.channel = function channel<T extends object>(
+  this: Pattern<T>,
+  value: ChannelIndex,
+): Pattern<T & { ch: ChannelIndex }> {
+  return this.ch(value);
+} as AnySetter as Pattern<object>['channel'];
+
+Pattern.prototype.speed = function speed<T extends object>(
+  this: Pattern<T>,
+  value: Speed,
+): Pattern<T & { speed: Speed }> {
+  return this.map((v) => ({ ...v, speed: value }));
+} as AnySetter as Pattern<object>['speed'];

--- a/src/pico8/errors.ts
+++ b/src/pico8/errors.ts
@@ -1,0 +1,30 @@
+/**
+ * Error codes surfaced by the PICO-8 layer. Each code names a specific
+ * validation failure so callers can programmatically discriminate
+ * between (e.g.) "you passed an unknown instrument name" and "you
+ * stacked too many channels".
+ *
+ * Codes are stable — renaming one is a breaking change.
+ */
+export type Pico8ErrorCode =
+  | 'PICO8_UNKNOWN_INSTRUMENT'
+  | 'PICO8_UNKNOWN_EFFECT'
+  | 'PICO8_INVALID_PITCH'
+  | 'PICO8_INVALID_VOLUME'
+  | 'PICO8_INVALID_SPEED'
+  | 'PICO8_TOO_MANY_CHANNELS'
+  | 'PICO8_SONG_LOOP_OUT_OF_RANGE';
+
+/**
+ * Error thrown by the PICO-8 layer. Carries a stable `code` alongside
+ * the human-readable message so catch sites can match on the code.
+ */
+export class Pico8Error extends Error {
+  readonly code: Pico8ErrorCode;
+
+  constructor(code: Pico8ErrorCode, message: string) {
+    super(message);
+    this.name = 'Pico8Error';
+    this.code = code;
+  }
+}

--- a/src/pico8/index.ts
+++ b/src/pico8/index.ts
@@ -1,3 +1,10 @@
+// Importing this module triggers `Pattern.prototype` augmentation —
+// after any import of `@loom/pico8`, every `Pattern<T>` instance
+// exposes the chainable setters (`.inst`, `.vol`, `.fx`, `.ch`,
+// `.speed`, plus their long aliases).
+import '@loom/pico8/augment.js';
+
+export type { ChannelIndex, Pico8Attributes } from '@loom/pico8/attributes.js';
 export {
   type Effect,
   effectIdFromName,
@@ -5,6 +12,7 @@ export {
   effectNameFromId,
   EFFECTS,
 } from '@loom/pico8/effects.js';
+export { Pico8Error, type Pico8ErrorCode } from '@loom/pico8/errors.js';
 export {
   BUILTIN_INSTRUMENTS,
   type BuiltinInstrument,


### PR DESCRIPTION
## Summary

Augments `Pattern.prototype` with Strudel-style chainable setters that merge PICO-8 attributes into each event's value. Importing `@loom/pico8` lights them up on every `Pattern` instance with full IntelliSense.

### New methods

| Short | Long | Value | Attr |
|---|---|---|---|
| `.inst(x)` | `.instrument(x)` | `0-15` / `InstrumentName` / `Pattern<InstrumentId>` | `inst` |
| `.vol(n)` | `.volume(n)` | `Volume` / `Pattern<Volume>` | `vol` |
| `.fx(x)` | `.effect(x)` | `0-7` / `EffectName` / `Pattern<EffectId>` | `fx` |
| `.ch(n)` | `.channel(n)` | `0\|1\|2\|3` (enforced at the type level) | `ch` |
| `.speed(n)` | — | `Speed` | `speed` |

### Semantics

- **Primitive value:** applies uniformly to every event (`.map(v => ({ ...v, vol: n }))`).
- **`Pattern<T>` value:** zips per step. For each base event, look up a value active at the event's `begin` time; if none, the event is dropped. The value pattern acts as *structure*.
- **Type-level protection:** the `this: Pattern<T & object>` constraint on every declaration rejects calls on a `Pattern<primitive>` at compile time — spreading a primitive silently discards the value (`{...48}` is `{}`), so the compiler blocks that footgun up front.
- **String resolution:** `'triangle'` → `0`, `'fade-in'` → `4`, etc. Invalid names throw `Pico8Error` with stable codes `PICO8_UNKNOWN_INSTRUMENT` / `PICO8_UNKNOWN_EFFECT`.
- **No runtime range validation in the core** — deferred to the adapter at render time, per CLAUDE.md.

### New public API

- `Pico8Error` / `Pico8ErrorCode` — stable error-code hierarchy
- `ChannelIndex` / `Pico8Attributes` — adapter-facing attribute shape
- All 10 chainable setters via module augmentation on `@loom/core/pattern.js`

Closes #8.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` — 117 tests, every setter exercised on numeric, named, and `Pattern` inputs; chain composition verified
- [x] `bun run test:cov` — 100/97.7/100/100
- [x] Multi-event zip test confirms per-step-varying `.vol(seq(...))` behaviour end-to-end

## Review loop
Self-review flagged 3 items (non-object-T footgun, missing multi-event zip test, clarifying comment for `Pico8Attributes`). All addressed via autosquashed fixup. LGTM at round 2.