### PR TITLE
feat(pico8): validate max-4-channels on stacked patterns

### DIFF
--- a/.changeset/pico8-validate.md
+++ b/.changeset/pico8-validate.md
@@ -1,0 +1,9 @@
+---
+"loom": minor
+---
+
+**pico8:** ship `pico8Validate(pattern, cycles)` — a pre-flight check that throws `Pico8Error('PICO8_TOO_MANY_CHANNELS')` if any instant has more than `MUSIC_CHANNELS_MAX` (= 4) distinct channels active. Events with no `.ch` default to channel 0; concurrent same-channel events are allowed (PICO-8's last-hit-wins semantics).
+
+The error carries a structured `details: { at: string; channels: ChannelIndex[] }` payload naming the offending cycle instant and the colliding channel ids. Use for CLI warnings (`loom events`) and as the template the Web Audio adapter (#15) enforces at query time.
+
+Also extends `Pico8Error` with an optional `details` field for machine-readable error payloads.

--- a/src/pico8/errors.ts
+++ b/src/pico8/errors.ts
@@ -16,15 +16,19 @@ export type Pico8ErrorCode =
   | 'PICO8_SONG_LOOP_OUT_OF_RANGE';
 
 /**
- * Error thrown by the PICO-8 layer. Carries a stable `code` alongside
- * the human-readable message so catch sites can match on the code.
+ * Error thrown by the PICO-8 layer. Carries a stable `code`, a
+ * human-readable message, and an optional `details` payload with
+ * machine-readable context (e.g. `{ at: cycle, channels: [...] }`
+ * for `PICO8_TOO_MANY_CHANNELS`).
  */
 export class Pico8Error extends Error {
   readonly code: Pico8ErrorCode;
+  readonly details: Readonly<Record<string, unknown>> | undefined;
 
-  constructor(code: Pico8ErrorCode, message: string) {
+  constructor(code: Pico8ErrorCode, message: string, details?: Readonly<Record<string, unknown>>) {
     super(message);
     this.name = 'Pico8Error';
     this.code = code;
+    this.details = details;
   }
 }

--- a/src/pico8/index.ts
+++ b/src/pico8/index.ts
@@ -51,3 +51,4 @@ export {
   VOLUME_MAX,
   VOLUME_MIN,
 } from '@loom/pico8/types.js';
+export { type Pico8TooManyChannelsDetails, pico8Validate } from '@loom/pico8/validate.js';

--- a/src/pico8/validate.test.ts
+++ b/src/pico8/validate.test.ts
@@ -1,0 +1,133 @@
+import '@loom/pico8/augment.js';
+
+import { cat, pure, silence, stack } from '@loom/core/primitives.js';
+import { Time } from '@loom/core/time.js';
+import { Pico8Error } from '@loom/pico8/errors.js';
+import { type Pico8TooManyChannelsDetails, pico8Validate } from '@loom/pico8/validate.js';
+import { describe, expect, it } from 'vitest';
+
+describe('pico8Validate', () => {
+  it('passes when every instant has <= 4 distinct channels', () => {
+    const pattern = stack(
+      pure({ pitch: 48 }).ch(0),
+      pure({ pitch: 52 }).ch(1),
+      pure({ pitch: 55 }).ch(2),
+      pure({ pitch: 60 }).ch(3),
+    );
+    expect(() => {
+      pico8Validate(pattern, 1);
+    }).not.toThrow();
+  });
+
+  it('treats events with no .ch as channel 0', () => {
+    const pattern = stack(pure({ pitch: 48 }), pure({ pitch: 52 }));
+    // Both default to ch 0 — one distinct channel, not a collision.
+    expect(() => {
+      pico8Validate(pattern, 1);
+    }).not.toThrow();
+  });
+
+  it('allows concurrent same-channel events (PICO-8 last-hit-wins)', () => {
+    const pattern = stack(
+      pure({ pitch: 48 }).ch(0),
+      pure({ pitch: 52 }).ch(0),
+      pure({ pitch: 55 }).ch(0),
+      pure({ pitch: 60 }).ch(0),
+      pure({ pitch: 63 }).ch(0),
+    );
+    // Five events, same channel — one distinct channel, still under 4.
+    expect(() => {
+      pico8Validate(pattern, 1);
+    }).not.toThrow();
+  });
+
+  it('throws when >4 distinct channels collide at an instant', () => {
+    // ChannelIndex is typed `0|1|2|3`, so `.ch(4)` is a compile
+    // error. To exercise the runtime path we inject a 5th channel
+    // via an ad-hoc event value — simulating a malformed source
+    // (e.g. a buggy `.p8` parser) that hands off out-of-range ids.
+    const pattern = stack(
+      pure({ pitch: 48 }).ch(0),
+      pure({ pitch: 52 }).ch(1),
+      pure({ pitch: 55 }).ch(2),
+      pure({ pitch: 60 }).ch(3),
+      pure({ pitch: 63, ch: 4 as unknown as 0 }),
+    );
+    try {
+      pico8Validate(pattern, 1);
+      expect.fail('expected throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Pico8Error);
+      const err = error as Pico8Error;
+      expect(err.code).toBe('PICO8_TOO_MANY_CHANNELS');
+      const details = err.details as Pico8TooManyChannelsDetails;
+      expect(details.at).toBe(Time.ZERO.toString());
+      expect(details.channels).toEqual([0, 1, 2, 3, 4]);
+    }
+  });
+
+  it('flags the specific later cycle where the collision occurs', () => {
+    // cat rotates one subpattern per cycle. Cycle 0 is a safe single
+    // channel, cycle 1 adds a second, cycle 2 stacks five distinct
+    // channels and must blow up there specifically.
+    const safe0 = pure({ pitch: 48 }).ch(0);
+    const safe1 = stack(pure({ pitch: 48 }).ch(0), pure({ pitch: 52 }).ch(1));
+    const bust2 = stack(
+      pure({ pitch: 48 }).ch(0),
+      pure({ pitch: 52 }).ch(1),
+      pure({ pitch: 55 }).ch(2),
+      pure({ pitch: 60 }).ch(3),
+      pure({ pitch: 62, ch: 4 as unknown as 0 }),
+    );
+    const pattern = cat(safe0, safe1, bust2);
+    try {
+      pico8Validate(pattern, 3);
+      expect.fail('expected throw');
+    } catch (error) {
+      const err = error as Pico8Error;
+      expect(err.code).toBe('PICO8_TOO_MANY_CHANNELS');
+      const details = err.details as Pico8TooManyChannelsDetails;
+      // Collision happens at cycle index 2, which renders as "2".
+      expect(details.at).toBe('2');
+      expect(details.channels).toEqual([0, 1, 2, 3, 4]);
+    }
+  });
+
+  it('skips silent events (silence yields no channel claims)', () => {
+    // silence produces no events, so it doesn't contribute channels.
+    const pattern = stack(silence, pure({ pitch: 48 }).ch(0));
+    expect(() => {
+      pico8Validate(pattern, 1);
+    }).not.toThrow();
+  });
+
+  it('sorts channel ids ascending in the error payload', () => {
+    const pattern = stack(
+      pure({ pitch: 48, ch: 3 as unknown as 0 }),
+      pure({ pitch: 52, ch: 1 as unknown as 0 }),
+      pure({ pitch: 55, ch: 4 as unknown as 0 }),
+      pure({ pitch: 60, ch: 0 as const }),
+      pure({ pitch: 63, ch: 2 as unknown as 0 }),
+    );
+    try {
+      pico8Validate(pattern, 1);
+      expect.fail('expected throw');
+    } catch (error) {
+      const details = (error as Pico8Error).details as Pico8TooManyChannelsDetails;
+      expect(details.channels).toEqual([0, 1, 2, 3, 4]);
+    }
+  });
+
+  it('rejects non-positive cycles with a TypeError', () => {
+    const pattern = pure({ pitch: 48 });
+    expect(() => {
+      pico8Validate(pattern, 0);
+    }).toThrow(TypeError);
+    expect(() => {
+      pico8Validate(pattern, -1);
+    }).toThrow(TypeError);
+    expect(() => {
+      pico8Validate(pattern, 1.5);
+    }).toThrow(TypeError);
+  });
+});

--- a/src/pico8/validate.ts
+++ b/src/pico8/validate.ts
@@ -1,0 +1,68 @@
+import type { Pattern } from '@loom/core/pattern.js';
+import { Time } from '@loom/core/time.js';
+import type { ChannelIndex, Pico8Attributes } from '@loom/pico8/attributes.js';
+import { Pico8Error } from '@loom/pico8/errors.js';
+import { MUSIC_CHANNELS_MAX } from '@loom/pico8/types.js';
+
+/**
+ * Structured payload of a `PICO8_TOO_MANY_CHANNELS` error. `at` is
+ * the rational cycle instant (in `"num/den"` form) where the channel
+ * collision was detected; `channels` lists the distinct channel ids
+ * active at that instant, sorted ascending.
+ */
+export interface Pico8TooManyChannelsDetails extends Record<string, unknown> {
+  readonly at: string;
+  readonly channels: readonly ChannelIndex[];
+}
+
+/**
+ * Walks `pattern` over the first `cycles` cycles and throws
+ * `Pico8Error('PICO8_TOO_MANY_CHANNELS')` if any instant has more
+ * than `MUSIC_CHANNELS_MAX` distinct channels active simultaneously.
+ *
+ * Events with no `.ch` attribute default to channel 0. Concurrent
+ * same-channel events are allowed — PICO-8's last-hit-wins semantics
+ * means the actual render collapses them.
+ *
+ * Pre-flight check; the adapter layer calls this (or an equivalent
+ * streaming variant) at render time. CLI workflows use it too —
+ * `loom events` warns before emitting.
+ *
+ * @param pattern - Pattern whose events carry an optional `ch` attribute
+ * @param cycles - Positive integer — how many cycles to validate
+ * @throws `Pico8Error('PICO8_TOO_MANY_CHANNELS')` on collision
+ */
+export function pico8Validate(pattern: Pattern<Pico8Attributes>, cycles: number): void {
+  if (!Number.isInteger(cycles) || cycles <= 0) {
+    throw new TypeError(`pico8Validate: cycles must be a positive integer, got ${cycles}`);
+  }
+
+  const events = pattern.query(Time.ZERO, new Time(BigInt(cycles), 1n));
+
+  // Distinct-channel set per begin instant. Same-channel collisions
+  // collapse into a single set member; only distinct-channel pileups
+  // can exceed the four-voice ceiling.
+  const channelsByInstant = new Map<string, Set<ChannelIndex>>();
+  for (const event of events) {
+    const ch = event.value.ch ?? 0;
+    const key = event.begin.toString();
+    let bucket = channelsByInstant.get(key);
+    if (bucket === undefined) {
+      bucket = new Set<ChannelIndex>();
+      channelsByInstant.set(key, bucket);
+    }
+    bucket.add(ch);
+  }
+
+  for (const [at, bucket] of channelsByInstant) {
+    if (bucket.size > MUSIC_CHANNELS_MAX) {
+      const channels = [...bucket].toSorted((a, b) => a - b);
+      const details: Pico8TooManyChannelsDetails = { at, channels };
+      throw new Pico8Error(
+        'PICO8_TOO_MANY_CHANNELS',
+        `More than ${MUSIC_CHANNELS_MAX} distinct channels collide at cycle ${at}: [${channels.join(', ')}]`,
+        details,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Ships `pico8Validate(pattern, cycles)` — the pre-flight guard the PICO-8 adapter (and `loom events` CLI) uses to reject compositions that would require more than 4 concurrent channels.

### Semantics

- Walks the pattern over the first `cycles` cycles.
- For every distinct begin-instant, collects the set of distinct `ch` values. Same-channel collisions collapse (PICO-8's last-hit-wins).
- If any instant carries more than `MUSIC_CHANNELS_MAX` (= 4) distinct channels, throws `Pico8Error('PICO8_TOO_MANY_CHANNELS')` with a structured payload `{ at: string; channels: ChannelIndex[] }`.
- Events missing `.ch` default to channel 0.
- `cycles` must be a positive integer (`TypeError` otherwise).

### New public API

- `pico8Validate(pattern, cycles)` — the pre-flight function.
- `Pico8TooManyChannelsDetails` — the typed error payload.
- `Pico8Error.details` — optional structured data field added to the existing error class (non-breaking: existing 2-arg callers keep working).

### Follow-up (not blocking)

- [#46](https://github.com/salty-max/loom/issues/46) — cap `cycles` to prevent DoS from user input. Reviewer explicitly said "follow-up issue rather than blocking this PR".

Closes #9.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` — 127 tests; covers all-safe, same-channel collapse, cycle-0 collision, **later-cycle collision** (cat rotating a 5-channel stack into cycle 2), missing-ch default, silence composition, sorted payload, and non-positive-cycles `TypeError`.
- [x] `bun run test:cov` — 100/97.93/100/100
- [x] Changeset — minor bump on `loom`

## Review loop
Self-review flagged 2 items. One applied (tighten "later cycle" test to actually use a later cycle, via `cat`), one filed as [#46](https://github.com/salty-max/loom/issues/46) per the reviewer's own "follow-up issue" guidance. LGTM at round 2.