### PR TITLE
feat(pico8): song loop markers via .loop({start, end})

### DIFF
--- a/.changeset/pico8-loop.md
+++ b/.changeset/pico8-loop.md
@@ -1,0 +1,10 @@
+---
+"loom": minor
+---
+
+**pico8:** ship `Pattern.loop({ start, end })` and `getLoopRange()`.
+
+- `.loop({ start, end })` on any Pattern attaches song-loop metadata: cycle indices (zero-based, both inclusive) that the scheduler and `.p8` serializer read to decide where a song's repeating section lies. Returns a new Pattern — the source is untouched.
+- `getLoopRange(pattern)` reads the metadata back. Returns `undefined` if no `.loop()` was attached (the scheduler treats that as "play once and stop").
+- Basic shape validation runs at `.loop()` time — integer, non-negative, `start <= end`. Invalid shapes throw `Pico8Error('PICO8_SONG_LOOP_OUT_OF_RANGE')` with a `{ range }` details payload. Bounds against the actual cycle count are re-validated by downstream consumers that know the total span (adapters, `.p8` serializer).
+- Metadata lives in a `WeakMap` side channel so `core` stays dep-free of PICO-8 concerns; the range is garbage-collected alongside the Pattern it belongs to.

--- a/src/pico8/index.ts
+++ b/src/pico8/index.ts
@@ -1,8 +1,10 @@
-// Importing this module triggers `Pattern.prototype` augmentation —
+// Importing these modules triggers `Pattern.prototype` augmentation —
 // after any import of `@loom/pico8`, every `Pattern<T>` instance
 // exposes the chainable setters (`.inst`, `.vol`, `.fx`, `.ch`,
-// `.speed`, plus their long aliases).
+// `.speed`, plus their long aliases) and the `.loop({start, end})`
+// song-loop marker.
 import '@loom/pico8/augment.js';
+import '@loom/pico8/loop.js';
 
 export type { ChannelIndex, Pico8Attributes } from '@loom/pico8/attributes.js';
 export {
@@ -21,6 +23,7 @@ export {
   instrumentNameFromId,
   isBuiltin,
 } from '@loom/pico8/instruments.js';
+export { getLoopRange } from '@loom/pico8/loop.js';
 export {
   EFFECT_MAX,
   EFFECT_MIN,

--- a/src/pico8/loop.test.ts
+++ b/src/pico8/loop.test.ts
@@ -1,0 +1,142 @@
+// Side effect: attaches .inst/.ch on Pattern.prototype for the
+// "loop survives a prior setter" test.
+import '@loom/pico8/augment.js';
+
+import { cat, pure } from '@loom/core/primitives.js';
+import { Time } from '@loom/core/time.js';
+import { Pico8Error } from '@loom/pico8/errors.js';
+// Importing getLoopRange also runs loop.ts's top-level side effect
+// that attaches Pattern.prototype.loop.
+import { getLoopRange } from '@loom/pico8/loop.js';
+import type { LoopRange } from '@loom/pico8/types.js';
+import { describe, expect, it } from 'vitest';
+
+describe('pico8/loop — Pattern.loop()', () => {
+  it('attaches a loop range to a pattern, readable via getLoopRange', () => {
+    const song = cat(pure('intro'), pure('verse'), pure('groove'));
+    const looped = song.loop({ start: 2, end: 2 });
+
+    expect(getLoopRange(looped)).toEqual({ start: 2, end: 2 });
+  });
+
+  it('leaves the source pattern untouched (new Pattern instance)', () => {
+    const song = cat(pure('a'), pure('b'));
+    const looped = song.loop({ start: 0, end: 1 });
+
+    expect(looped).not.toBe(song);
+    expect(getLoopRange(song)).toBeUndefined();
+    expect(getLoopRange(looped)).toEqual({ start: 0, end: 1 });
+  });
+
+  it('preserves the pattern queries the source would produce', () => {
+    const song = cat(pure('a'), pure('b'));
+    const looped = song.loop({ start: 0, end: 1 });
+
+    const srcEvents = song.query(Time.ZERO, new Time(2n, 1n)).map((e) => e.value);
+    const loopEvents = looped.query(Time.ZERO, new Time(2n, 1n)).map((e) => e.value);
+    expect(loopEvents).toEqual(srcEvents);
+  });
+
+  it('allows start === end (loop a single position)', () => {
+    const song = cat(pure('a'), pure('b'), pure('c'));
+    const looped = song.loop({ start: 1, end: 1 });
+    expect(getLoopRange(looped)).toEqual({ start: 1, end: 1 });
+  });
+
+  it('later .loop() calls replace the range on a fresh instance', () => {
+    const song = cat(pure('a'), pure('b'), pure('c'));
+    const first = song.loop({ start: 0, end: 1 });
+    const second = first.loop({ start: 1, end: 2 });
+
+    expect(getLoopRange(first)).toEqual({ start: 0, end: 1 });
+    expect(getLoopRange(second)).toEqual({ start: 1, end: 2 });
+    expect(first).not.toBe(second);
+  });
+
+  describe('validation', () => {
+    it('throws PICO8_SONG_LOOP_OUT_OF_RANGE on negative start', () => {
+      const song = cat(pure('a'), pure('b'));
+      try {
+        song.loop({ start: -1, end: 1 });
+        expect.fail('expected throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(Pico8Error);
+        expect((error as Pico8Error).code).toBe('PICO8_SONG_LOOP_OUT_OF_RANGE');
+      }
+    });
+
+    it('throws when end < start', () => {
+      const song = cat(pure('a'), pure('b'));
+      try {
+        song.loop({ start: 1, end: 0 });
+        expect.fail('expected throw');
+      } catch (error) {
+        expect((error as Pico8Error).code).toBe('PICO8_SONG_LOOP_OUT_OF_RANGE');
+      }
+    });
+
+    it('throws on non-integer start or end', () => {
+      const song = cat(pure('a'), pure('b'));
+      for (const range of [
+        { start: 0.5, end: 1 },
+        { start: 0, end: 1.5 },
+      ] satisfies LoopRange[]) {
+        try {
+          song.loop(range);
+          expect.fail(`expected throw for ${JSON.stringify(range)}`);
+        } catch (error) {
+          expect((error as Pico8Error).code).toBe('PICO8_SONG_LOOP_OUT_OF_RANGE');
+        }
+      }
+    });
+
+    it('surfaces the offending range in the error details', () => {
+      const song = cat(pure('a'));
+      try {
+        song.loop({ start: 5, end: 2 });
+        expect.fail('expected throw');
+      } catch (error) {
+        const err = error as Pico8Error;
+        expect(err.details).toEqual({ range: { start: 5, end: 2 } });
+      }
+    });
+  });
+});
+
+describe('pico8/loop — getLoopRange', () => {
+  it('returns undefined for a pattern without a loop', () => {
+    const song = cat(pure('a'), pure('b'));
+    expect(getLoopRange(song)).toBeUndefined();
+  });
+});
+
+describe('pico8/loop — interaction with other setters', () => {
+  it('loop metadata survives when .loop() is chained AFTER another setter', () => {
+    // .ch(0).loop(...) applies the channel first, then attaches loop
+    // metadata to the resulting Pattern. getLoopRange reads it.
+    const song = cat(pure({ pitch: 48 }), pure({ pitch: 52 }))
+      .ch(0)
+      .loop({ start: 0, end: 1 });
+    expect(getLoopRange(song)).toEqual({ start: 0, end: 1 });
+  });
+
+  it('loop metadata does NOT survive transforms applied AFTER .loop()', () => {
+    // .loop() attaches metadata to its returned Pattern. Any
+    // downstream transform (.map, .ch, etc.) produces a fresh
+    // Pattern instance that is not a key in the WeakMap, so the
+    // range is gone — consistent with the fact that downstream
+    // transforms can shift event timings and invalidate cycle
+    // indices.
+    const looped = cat(pure({ pitch: 48 }), pure({ pitch: 52 })).loop({
+      start: 0,
+      end: 1,
+    });
+    expect(getLoopRange(looped)).toEqual({ start: 0, end: 1 });
+
+    const mapped = looped.map((v) => v);
+    expect(getLoopRange(mapped)).toBeUndefined();
+
+    const channelled = looped.ch(0);
+    expect(getLoopRange(channelled)).toBeUndefined();
+  });
+});

--- a/src/pico8/loop.ts
+++ b/src/pico8/loop.ts
@@ -1,0 +1,72 @@
+import { Pattern } from '@loom/core/pattern.js';
+import { Pico8Error } from '@loom/pico8/errors.js';
+import type { LoopRange } from '@loom/pico8/types.js';
+
+declare module '@loom/core/pattern.js' {
+  interface Pattern<T> {
+    /**
+     * Attaches a song-loop range to the pattern. The scheduler (and
+     * `.p8` serializer) reads the range to decide where to loop: once
+     * playback reaches the cycle at `end`, the next cycle resumes at
+     * `start` and repeats until stopped.
+     *
+     * Indices count cycle positions inside the outer pattern,
+     * zero-based, both inclusive. Without `.loop()`, a pattern plays
+     * once and the scheduler emits silence after.
+     *
+     * Basic shape validation runs here: integer, non-negative,
+     * `start <= end`. Bounds against the actual cycle count are
+     * re-validated by consumers (adapters, `.p8` serializer) that
+     * know the total cycle span.
+     *
+     * Invalid shapes throw `Pico8Error('PICO8_SONG_LOOP_OUT_OF_RANGE')`.
+     *
+     * @param range - `{ start, end }` cycle indices, both inclusive
+     * @returns A new Pattern carrying the loop metadata
+     */
+    loop(range: LoopRange): Pattern<T>;
+  }
+}
+
+// Side-channel storage — keeps the loop metadata out of the core
+// Pattern class so `core` stays dep-free of PICO-8 concerns. The
+// WeakMap is keyed on Pattern instances so loop metadata is gc'd
+// alongside the pattern it belongs to.
+const LOOP_RANGES = new WeakMap<Pattern<unknown>, LoopRange>();
+
+/**
+ * Returns the loop range attached to `pattern` via `.loop()`, or
+ * `undefined` if none. Consumed by the runtime scheduler (#25) and
+ * the `.p8` serializer (#11).
+ *
+ * @param pattern - Any Pattern
+ * @returns The loop range, or `undefined` if no `.loop()` was attached
+ */
+export function getLoopRange(pattern: Pattern<unknown>): LoopRange | undefined {
+  return LOOP_RANGES.get(pattern);
+}
+
+function validateLoopRange(range: LoopRange): void {
+  if (
+    !Number.isInteger(range.start) ||
+    !Number.isInteger(range.end) ||
+    range.start < 0 ||
+    range.end < range.start
+  ) {
+    throw new Pico8Error(
+      'PICO8_SONG_LOOP_OUT_OF_RANGE',
+      `Invalid loop range {start: ${range.start}, end: ${range.end}}: require non-negative integers with start <= end`,
+      { range },
+    );
+  }
+}
+
+Pattern.prototype.loop = function loop<T>(this: Pattern<T>, range: LoopRange): Pattern<T> {
+  validateLoopRange(range);
+  // Wrap the query rather than mutate this Pattern — immutability
+  // mirrors the event-value setters, and cloning ensures repeated
+  // `.loop()` calls replace the metadata on distinct instances.
+  const copy = new Pattern<T>((begin, end) => this.query(begin, end));
+  LOOP_RANGES.set(copy, { start: range.start, end: range.end });
+  return copy;
+};


### PR DESCRIPTION
## Summary

Adds song-structure loop metadata to the PICO-8 layer:

- **`Pattern.prototype.loop({ start, end })`** — chainable method that attaches a loop range (both-inclusive cycle indices) to the returned Pattern. Downstream consumers (scheduler #25, `.p8` serializer #11) read it to decide where a song's repeating section lies.
- **`getLoopRange(pattern)`** — reader that returns the range or `undefined`.
- **Shape validation at `.loop()` time** — integer, non-negative, `start <= end`. Throws `Pico8Error('PICO8_SONG_LOOP_OUT_OF_RANGE')` with a `{ range }` details payload on invalid shapes. Bounds vs. actual cycle count are deferred to consumers (the total span isn't derivable from an opaque `Pattern<T>`).
- **Metadata lives in a `WeakMap` side channel** keyed on Pattern instances, keeping `core` dep-free of PICO-8 concerns. `.loop()` wraps `this.query` into a fresh Pattern and attaches the range there — preserving immutability and making repeated `.loop()` calls produce distinct instances with independent metadata.

### What ships today vs what defers

Several AC items from #10 depend on PRs not yet landed (#25 runtime scheduler, #11 `.p8` roundtrip). This PR ships the metadata + reader so those future PRs have the hooks they need. The scheduler behaviour ("plays once without `.loop()`, loops [start, end] with `.loop()`") and the serializer emit/import semantics are out of scope here — they're explicit dependencies in #10.

### Interaction semantics

- `cat(...).ch(0).loop({...})` — range attaches to the final Pattern. `getLoopRange` returns it.
- `cat(...).loop({...}).map(...)` or `.ch(...)` — downstream transforms produce a new Pattern without the metadata. This is correct: transforms can shift event timings and invalidate cycle indices.

Closes #10.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` — 141 tests, includes attach, identity, query-preservation, single-position loop, replace-on-call, error payload, downstream-transform-drops-metadata, setter-then-loop-preserves-metadata.
- [x] `bun run test:cov` — 100/98.09/100/100
- [x] Changeset — minor bump on `loom`

## Review loop
Self-review flagged two required items (add tests for transform-interaction semantics, drop a redundant side-effect import) — both applied via autosquashed fixup. LGTM at round 2.