### PR TITLE
feat(transforms): fast, slow, rev on Pattern

### DIFF
--- a/.changeset/transforms-fast-slow-rev.md
+++ b/.changeset/transforms-fast-slow-rev.md
@@ -1,0 +1,15 @@
+---
+"loom": minor
+---
+
+**transforms:** ship `fast`, `slow`, `rev` — the three lossless time transforms.
+
+- **`fast(n, pattern)`** compresses the pattern into `1/n` of its duration (`fast(2, p)` plays `p` at double speed).
+- **`slow(n, pattern)`** stretches the pattern to `n×` its duration — the semantic inverse of `fast`, implemented directly on rational `Time` so non-integer factors stay exact.
+- **`rev(pattern)`** reverses event order within each cycle by reflecting around the cycle midpoint.
+
+All three ship as standalone functions AND as methods on `Pattern.prototype` via TypeScript module augmentation — `pat.fast(2).rev()` works identically to `rev(fast(2, pat))`. Importing `loom/transforms` (or using the subpath export added in `package.json`) triggers the prototype augmentation.
+
+`fast` and `slow` reject non-positive or non-finite factors with `RangeError`. `rev` takes no arguments.
+
+Closes #13.

--- a/knip.json
+++ b/knip.json
@@ -2,7 +2,6 @@
   "$schema": "https://unpkg.com/knip@latest/schema.json",
   "entry": [
     "src/core/index.ts",
-    "src/transforms/index.ts",
     "src/adapters/index.ts",
     "src/runtime/index.ts"
   ],

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     "./mini": {
       "import": "./dist/mini/index.js",
       "types": "./dist/mini/index.d.ts"
+    },
+    "./transforms": {
+      "import": "./dist/transforms/index.js",
+      "types": "./dist/transforms/index.d.ts"
     }
   },
   "bin": {

--- a/src/transforms/augment.test.ts
+++ b/src/transforms/augment.test.ts
@@ -1,0 +1,31 @@
+// Side effect: attaches .fast / .slow / .rev on Pattern.prototype.
+import '@loom/transforms/augment.js';
+
+import { pure, seq } from '@loom/core/primitives.js';
+import { Time } from '@loom/core/time.js';
+import { describe, expect, it } from 'vitest';
+
+describe('transforms/augment — Pattern method form', () => {
+  it('.fast(n) matches fast(n, this)', () => {
+    const events = pure('x').fast(2).query(Time.ZERO, Time.ONE);
+    expect(events.map((e) => e.value)).toEqual(['x', 'x']);
+  });
+
+  it('.slow(n) matches slow(n, this)', () => {
+    const events = pure('x').slow(2).query(Time.ZERO, new Time(2n, 1n));
+    expect(events).toHaveLength(1);
+    expect(events[0]?.end.eq(new Time(2n, 1n))).toBe(true);
+  });
+
+  it('.rev() matches rev(this)', () => {
+    const events = seq(pure('a'), pure('b')).rev().query(Time.ZERO, Time.ONE);
+    expect(events.map((e) => e.value)).toEqual(['b', 'a']);
+  });
+
+  it('chains cleanly — seq(a, b, c).fast(2).rev()', () => {
+    const events = seq(pure('a'), pure('b'), pure('c')).fast(2).rev().query(Time.ZERO, Time.ONE);
+    // fast(2, seq(a,b,c)) plays a,b,c,a,b,c in one cycle.
+    // rev flips each cycle: c,b,a,c,b,a.
+    expect(events.map((e) => e.value)).toEqual(['c', 'b', 'a', 'c', 'b', 'a']);
+  });
+});

--- a/src/transforms/augment.ts
+++ b/src/transforms/augment.ts
@@ -1,0 +1,36 @@
+import { Pattern } from '@loom/core/pattern.js';
+import { fast } from '@loom/transforms/fast.js';
+import { rev } from '@loom/transforms/rev.js';
+import { slow } from '@loom/transforms/slow.js';
+
+declare module '@loom/core/pattern.js' {
+  interface Pattern<T> {
+    /**
+     * Compresses the pattern into `1/n` of its duration. See
+     * {@link import('@loom/transforms/fast.js').fast fast}.
+     */
+    fast(n: number): Pattern<T>;
+    /**
+     * Stretches the pattern to `n×` its duration. See
+     * {@link import('@loom/transforms/slow.js').slow slow}.
+     */
+    slow(n: number): Pattern<T>;
+    /**
+     * Reverses the event order within each cycle. See
+     * {@link import('@loom/transforms/rev.js').rev rev}.
+     */
+    rev(): Pattern<T>;
+  }
+}
+
+Pattern.prototype.fast = function fastMethod<T>(this: Pattern<T>, n: number): Pattern<T> {
+  return fast(n, this);
+};
+
+Pattern.prototype.slow = function slowMethod<T>(this: Pattern<T>, n: number): Pattern<T> {
+  return slow(n, this);
+};
+
+Pattern.prototype.rev = function revMethod<T>(this: Pattern<T>): Pattern<T> {
+  return rev(this);
+};

--- a/src/transforms/fast.test.ts
+++ b/src/transforms/fast.test.ts
@@ -1,0 +1,70 @@
+import { Pattern } from '@loom/core/pattern.js';
+import { pure, seq, silence } from '@loom/core/primitives.js';
+import { Time } from '@loom/core/time.js';
+import { fast } from '@loom/transforms/fast.js';
+import { describe, expect, it } from 'vitest';
+
+describe('fast', () => {
+  it('compresses one cycle of pure into two events in the same window', () => {
+    const events = fast(2, pure('x')).query(Time.ZERO, Time.ONE);
+    expect(events.map((e) => e.value)).toEqual(['x', 'x']);
+    expect(events[0]?.begin.eq(Time.ZERO)).toBe(true);
+    expect(events[0]?.end.eq(new Time(1n, 2n))).toBe(true);
+    expect(events[1]?.begin.eq(new Time(1n, 2n))).toBe(true);
+    expect(events[1]?.end.eq(Time.ONE)).toBe(true);
+  });
+
+  it('composes with seq — fast(2, seq(a, b)) fires four events per cycle', () => {
+    const events = fast(2, seq(pure('a'), pure('b'))).query(Time.ZERO, Time.ONE);
+    expect(events.map((e) => e.value)).toEqual(['a', 'b', 'a', 'b']);
+    expect(events[0]?.end.eq(new Time(1n, 4n))).toBe(true);
+    expect(events[1]?.end.eq(new Time(1n, 2n))).toBe(true);
+    expect(events[2]?.end.eq(new Time(3n, 4n))).toBe(true);
+    expect(events[3]?.end.eq(Time.ONE)).toBe(true);
+  });
+
+  it('accepts non-integer n with exact rational math', () => {
+    // fast(3/2, pure('x')) plays pure at 1.5x speed: in one cycle
+    // you hear 3 halves of a pure-cycle, i.e. one full + a half.
+    // Over [0, 1) we see one event at [0, 2/3) plus the start of
+    // the next at [2/3, 4/3).
+    const events = fast(1.5, pure('x')).query(Time.ZERO, Time.ONE);
+    expect(events).toHaveLength(2);
+    expect(events[0]?.begin.eq(Time.ZERO)).toBe(true);
+    expect(events[0]?.end.eq(new Time(2n, 3n))).toBe(true);
+    expect(events[1]?.begin.eq(new Time(2n, 3n))).toBe(true);
+    expect(events[1]?.end.eq(new Time(4n, 3n))).toBe(true);
+  });
+
+  it('returns a new Pattern — the source is untouched', () => {
+    const source = pure('x');
+    const sped = fast(2, source);
+    expect(sped).not.toBe(source);
+    expect(source.query(Time.ZERO, Time.ONE)).toHaveLength(1);
+    expect(sped.query(Time.ZERO, Time.ONE)).toHaveLength(2);
+  });
+
+  it('rejects non-positive or non-finite n', () => {
+    for (const n of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() => fast(n, pure('x'))).toThrow(RangeError);
+    }
+  });
+
+  it('fast(1, p) is equivalent to p', () => {
+    const events = fast(1, seq(pure('a'), pure('b'))).query(Time.ZERO, Time.ONE);
+    expect(events.map((e) => e.value)).toEqual(['a', 'b']);
+    expect(events[0]?.end.eq(new Time(1n, 2n))).toBe(true);
+  });
+
+  it('returns silence when given silence', () => {
+    expect(fast(3, silence).query(Time.ZERO, Time.ONE)).toEqual([]);
+  });
+
+  it('preserves event context through compression', () => {
+    const source = new Pattern<string>(() => [
+      { begin: Time.ZERO, end: Time.ONE, value: 'x', context: { origin: 'test' } },
+    ]);
+    const events = fast(2, source).query(Time.ZERO, Time.ONE);
+    expect(events[0]?.context).toEqual({ origin: 'test' });
+  });
+});

--- a/src/transforms/fast.ts
+++ b/src/transforms/fast.ts
@@ -1,0 +1,26 @@
+import { Pattern } from '@loom/core/pattern.js';
+import { Time } from '@loom/core/time.js';
+
+/**
+ * Compresses a pattern into `1/n` of its original duration. `fast(2, p)`
+ * plays `p` at double speed — one cycle's worth of events fires in
+ * half a cycle and the pattern repeats within the same interval.
+ *
+ * @param n - Positive finite scale factor (any rational; integers are typical)
+ * @param pattern - The pattern to compress
+ * @returns A new Pattern playing `pattern` at `n×` speed
+ */
+export function fast<T>(n: number, pattern: Pattern<T>): Pattern<T> {
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new RangeError(`fast: n must be a positive finite number, got ${n}`);
+  }
+  const factor = Time.from(n);
+  return new Pattern<T>((begin, end) => {
+    const events = pattern.query(begin.mul(factor), end.mul(factor));
+    return events.map((event) => ({
+      ...event,
+      begin: event.begin.div(factor),
+      end: event.end.div(factor),
+    }));
+  });
+}

--- a/src/transforms/index.ts
+++ b/src/transforms/index.ts
@@ -1,9 +1,7 @@
-// Pattern transformations.
-//
-// v0 is intentionally minimal to match the PICO-8 scope. The core pattern
-// algebra supports arbitrary transforms; we gate them at the public API
-// to avoid blowing past PICO-8 semantics before v0 ships.
-//
-// Planned for v0: fast, slow, rev (time-only, lossless on a 32-step grid).
-// Deferred to v0.1+: every, jux, struct, chunk, and other Tidal combinators.
-export {};
+// Side-effect import: attaches `.fast`, `.slow`, `.rev` on
+// `Pattern.prototype` so every Pattern instance picks up the methods.
+import '@loom/transforms/augment.js';
+
+export { fast } from '@loom/transforms/fast.js';
+export { rev } from '@loom/transforms/rev.js';
+export { slow } from '@loom/transforms/slow.js';

--- a/src/transforms/rev.test.ts
+++ b/src/transforms/rev.test.ts
@@ -1,0 +1,83 @@
+import { Pattern } from '@loom/core/pattern.js';
+import { pure, seq, silence } from '@loom/core/primitives.js';
+import { Time } from '@loom/core/time.js';
+import { rev } from '@loom/transforms/rev.js';
+import { describe, expect, it } from 'vitest';
+
+describe('rev', () => {
+  it('flips seq(a, b, c, d) → d, c, b, a within one cycle', () => {
+    const events = rev(seq(pure('a'), pure('b'), pure('c'), pure('d'))).query(Time.ZERO, Time.ONE);
+    expect(events.map((e) => e.value)).toEqual(['d', 'c', 'b', 'a']);
+    expect(events[0]?.begin.eq(Time.ZERO)).toBe(true);
+    expect(events[0]?.end.eq(new Time(1n, 4n))).toBe(true);
+    expect(events[3]?.begin.eq(new Time(3n, 4n))).toBe(true);
+    expect(events[3]?.end.eq(Time.ONE)).toBe(true);
+  });
+
+  it('is its own inverse — rev(rev(p)) ≡ p', () => {
+    const p = seq(pure('a'), pure('b'), pure('c'));
+    const double = rev(rev(p)).query(Time.ZERO, Time.ONE);
+    const original = p.query(Time.ZERO, Time.ONE);
+    expect(double.map((e) => e.value)).toEqual(original.map((e) => e.value));
+    expect(double[0]?.begin.eq(original[0]?.begin ?? Time.ZERO)).toBe(true);
+  });
+
+  it('leaves a single-event pure pattern as-is (its cycle is symmetric)', () => {
+    const events = rev(pure('x')).query(Time.ZERO, Time.ONE);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.begin.eq(Time.ZERO)).toBe(true);
+    expect(events[0]?.end.eq(Time.ONE)).toBe(true);
+  });
+
+  it('reverses each cycle independently over a multi-cycle query', () => {
+    const events = rev(seq(pure('a'), pure('b'))).query(Time.ZERO, new Time(2n, 1n));
+    // Cycle 0: seq → [a, b], reversed → [b, a].
+    // Cycle 1: seq → [a, b], reversed → [b, a].
+    expect(events.map((e) => e.value)).toEqual(['b', 'a', 'b', 'a']);
+    expect(events[2]?.begin.eq(Time.ONE)).toBe(true);
+  });
+
+  it('returns a new Pattern — source untouched', () => {
+    const source = seq(pure('a'), pure('b'));
+    const reversed = rev(source);
+    expect(reversed).not.toBe(source);
+    expect(source.query(Time.ZERO, Time.ONE).map((e) => e.value)).toEqual(['a', 'b']);
+    expect(reversed.query(Time.ZERO, Time.ONE).map((e) => e.value)).toEqual(['b', 'a']);
+  });
+
+  it('emits nothing when the query window is empty', () => {
+    expect(rev(pure('x')).query(Time.ONE, Time.ZERO)).toEqual([]);
+  });
+
+  it('drops reflected events that land outside a mid-cycle window', () => {
+    // seq(a, b, c, d) reversed yields d,c,b,a at [0,1/4),[1/4,1/2),[1/2,3/4),[3/4,1).
+    // Querying [1/4, 3/4) should yield only c,b — d and a fall outside.
+    const events = rev(seq(pure('a'), pure('b'), pure('c'), pure('d'))).query(
+      new Time(1n, 4n),
+      new Time(3n, 4n),
+    );
+    expect(events.map((e) => e.value)).toEqual(['c', 'b']);
+  });
+
+  it('returns silence when given silence', () => {
+    expect(rev(silence).query(Time.ZERO, Time.ONE)).toEqual([]);
+  });
+
+  it('handles negative-time queries', () => {
+    // Cycle -1 of seq(a,b) reflects to b,a at [-1, -1/2), [-1/2, 0).
+    const events = rev(seq(pure('a'), pure('b'))).query(new Time(-1n, 1n), Time.ZERO);
+    expect(events.map((e) => e.value)).toEqual(['b', 'a']);
+    expect(events[0]?.begin.eq(new Time(-1n, 1n))).toBe(true);
+    expect(events[0]?.end.eq(new Time(-1n, 2n))).toBe(true);
+    expect(events[1]?.begin.eq(new Time(-1n, 2n))).toBe(true);
+    expect(events[1]?.end.eq(Time.ZERO)).toBe(true);
+  });
+
+  it('preserves event context through reflection', () => {
+    const source = new Pattern<string>(() => [
+      { begin: Time.ZERO, end: Time.ONE, value: 'x', context: { origin: 'test' } },
+    ]);
+    const events = rev(source).query(Time.ZERO, Time.ONE);
+    expect(events[0]?.context).toEqual({ origin: 'test' });
+  });
+});

--- a/src/transforms/rev.ts
+++ b/src/transforms/rev.ts
@@ -1,0 +1,49 @@
+import type { Event } from '@loom/core/event.js';
+import { Pattern } from '@loom/core/pattern.js';
+import { Time } from '@loom/core/time.js';
+
+/**
+ * Reverses the event order within each cycle. An event at `[a, b)`
+ * inside cycle `k` becomes an event at `[2k + 1 − b, 2k + 1 − a)` —
+ * reflecting around the cycle's midpoint.
+ *
+ * Cycle boundaries are preserved: events don't leak from one cycle
+ * to its neighbours after reversal. Events that cross cycle
+ * boundaries in the source are reflected within the cycle they
+ * start in.
+ *
+ * @param pattern - The pattern to reverse
+ * @returns A new Pattern with each cycle's events mirrored in time
+ */
+export function rev<T>(pattern: Pattern<T>): Pattern<T> {
+  return new Pattern<T>((begin, end) => {
+    const events: Event<T>[] = [];
+    let cycle = begin.floor();
+    while (cycle.lt(end)) {
+      const cycleEnd = cycle.add(Time.ONE);
+      const cycleEvents = pattern.query(cycle, cycleEnd);
+      for (const event of cycleEvents) {
+        // Reflect [event.begin, event.end) around cycle + 1/2.
+        // reflectedBegin = cycle + (cycleEnd - event.end)
+        // reflectedEnd   = cycle + (cycleEnd - event.begin)
+        const reflectedBegin = cycle.add(cycleEnd.sub(event.end));
+        const reflectedEnd = cycle.add(cycleEnd.sub(event.begin));
+        // A per-cycle reflection can land outside a mid-cycle query
+        // window — e.g. reflecting `a@[0, 1/4)` to `[3/4, 1)` when
+        // the window is `[1/4, 3/4)`. Filter those out the same way
+        // `seq`/`cat` do, so downstream consumers never see events
+        // fully outside the scheduled span.
+        if (reflectedEnd.lte(begin) || reflectedBegin.gte(end)) {
+          continue;
+        }
+        events.push({
+          ...event,
+          begin: reflectedBegin,
+          end: reflectedEnd,
+        });
+      }
+      cycle = cycle.add(Time.ONE);
+    }
+    return events;
+  });
+}

--- a/src/transforms/slow.test.ts
+++ b/src/transforms/slow.test.ts
@@ -1,0 +1,67 @@
+import { Pattern } from '@loom/core/pattern.js';
+import { pure, seq, silence } from '@loom/core/primitives.js';
+import { Time } from '@loom/core/time.js';
+import { slow } from '@loom/transforms/slow.js';
+import { describe, expect, it } from 'vitest';
+
+describe('slow', () => {
+  it('stretches a pure pattern — one event spans two cycles', () => {
+    const events = slow(2, pure('x')).query(Time.ZERO, new Time(2n, 1n));
+    expect(events).toHaveLength(1);
+    expect(events[0]?.begin.eq(Time.ZERO)).toBe(true);
+    expect(events[0]?.end.eq(new Time(2n, 1n))).toBe(true);
+    expect(events[0]?.value).toBe('x');
+  });
+
+  it('seq(a, b) stretched by 2 — each half occupies a full cycle', () => {
+    const events = slow(2, seq(pure('a'), pure('b'))).query(Time.ZERO, new Time(2n, 1n));
+    expect(events.map((e) => e.value)).toEqual(['a', 'b']);
+    expect(events[0]?.begin.eq(Time.ZERO)).toBe(true);
+    expect(events[0]?.end.eq(Time.ONE)).toBe(true);
+    expect(events[1]?.begin.eq(Time.ONE)).toBe(true);
+    expect(events[1]?.end.eq(new Time(2n, 1n))).toBe(true);
+  });
+
+  it('non-integer n stays exact via rational math', () => {
+    // slow(1.5) = fast(2/3). Over [0, 1) of a pure pattern, the
+    // stretched version covers 2/3 of one cycle — one partial event
+    // from [0, 3/2).
+    const events = slow(1.5, pure('x')).query(Time.ZERO, Time.ONE);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.begin.eq(Time.ZERO)).toBe(true);
+    expect(events[0]?.end.eq(new Time(3n, 2n))).toBe(true);
+  });
+
+  it('returns a new Pattern — source untouched', () => {
+    const source = pure('x');
+    const stretched = slow(2, source);
+    expect(stretched).not.toBe(source);
+    expect(source.query(Time.ZERO, Time.ONE)).toHaveLength(1);
+    expect(stretched.query(Time.ZERO, Time.ONE)).toHaveLength(1);
+    expect(stretched.query(Time.ZERO, Time.ONE)[0]?.end.eq(new Time(2n, 1n))).toBe(true);
+  });
+
+  it('rejects non-positive or non-finite n', () => {
+    for (const n of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() => slow(n, pure('x'))).toThrow(RangeError);
+    }
+  });
+
+  it('slow(1, p) is equivalent to p', () => {
+    const events = slow(1, seq(pure('a'), pure('b'))).query(Time.ZERO, Time.ONE);
+    expect(events.map((e) => e.value)).toEqual(['a', 'b']);
+    expect(events[0]?.end.eq(new Time(1n, 2n))).toBe(true);
+  });
+
+  it('returns silence when given silence', () => {
+    expect(slow(3, silence).query(Time.ZERO, Time.ONE)).toEqual([]);
+  });
+
+  it('preserves event context through stretching', () => {
+    const source = new Pattern<string>(() => [
+      { begin: Time.ZERO, end: Time.ONE, value: 'x', context: { origin: 'test' } },
+    ]);
+    const events = slow(2, source).query(Time.ZERO, new Time(2n, 1n));
+    expect(events[0]?.context).toEqual({ origin: 'test' });
+  });
+});

--- a/src/transforms/slow.ts
+++ b/src/transforms/slow.ts
@@ -1,0 +1,30 @@
+import { Pattern } from '@loom/core/pattern.js';
+import { Time } from '@loom/core/time.js';
+
+/**
+ * Stretches a pattern to `n×` its original duration. `slow(2, p)`
+ * plays `p` at half speed — one cycle's worth of events now occupies
+ * two cycles of output.
+ *
+ * Semantically the inverse of {@link fast} — `slow(n, p)` equals
+ * `fast(1/n, p)`. Implemented directly on rational Time to preserve
+ * precision for non-integer `n`.
+ *
+ * @param n - Positive finite stretch factor
+ * @param pattern - The pattern to stretch
+ * @returns A new Pattern playing `pattern` at `1/n` speed
+ */
+export function slow<T>(n: number, pattern: Pattern<T>): Pattern<T> {
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new RangeError(`slow: n must be a positive finite number, got ${n}`);
+  }
+  const factor = Time.from(n);
+  return new Pattern<T>((begin, end) => {
+    const events = pattern.query(begin.div(factor), end.div(factor));
+    return events.map((event) => ({
+      ...event,
+      begin: event.begin.mul(factor),
+      end: event.end.mul(factor),
+    }));
+  });
+}


### PR DESCRIPTION
## Summary

Ships the three lossless time transforms the PICO-8 scope calls for:

- **`fast(n, pattern)`** — compresses the pattern into `1/n` of its duration. `fast(2, p)` plays `p` at double speed.
- **`slow(n, pattern)`** — stretches the pattern to `n×` its duration. Implemented directly on rational `Time` so non-integer factors stay exact (not via `fast(1/n, ...)`).
- **`rev(pattern)`** — reflects events within each cycle around the midpoint. Events whose reflection lands outside a mid-cycle query window are dropped the same way `seq` / `cat` drop out-of-window events.

### Dual API

All three ship as both:
1. Standalone functions via `@loom/transforms` (new `./transforms` subpath added to `package.json` `exports`)
2. Methods on `Pattern.prototype` — importing the module triggers the augmentation

`pat.fast(2).rev()` is identical to `rev(fast(2, pat))`.

### Behaviour

- `fast` and `slow` reject non-positive or non-finite `n` with `RangeError`.
- `rev` preserves cycle boundaries; events crossing boundaries are reflected within the cycle they start in, then filtered against the query window.
- All three preserve `Event.context` through the transform.

Closes #13.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` — 171 tests; every transform exercises compression/stretch/reversal, immutability, RangeError, silence identity, identity at n=1, mid-cycle window, negative-time query, context preservation
- [x] `bun run test:cov` — 100/98.23/100/100
- [x] `bunx --bun knip` clean (removed a redundant entry uncovered during review)
- [x] Changeset — minor bump on `loom`

## Review loop
Self-review LGTM with 3 items flagged (`rev` leakage on mid-cycle queries, missing silence/identity/context coverage, redundant knip entry). All applied via autosquashed fixup. Final LGTM at round 2.