### PR TITLE
feat(mini): minimal mini-notation parser (space-separated + ~ rests)

### DIFF
--- a/.changeset/mini-parser.md
+++ b/.changeset/mini-parser.md
@@ -1,0 +1,19 @@
+---
+"loom": minor
+---
+
+**mini:** ship `mini(source)` — the whitespace-separated mini-notation parser.
+
+- Tokens: note names (`c3`, `d#4`, `f#-1`, …) and the rest marker `~`. Note names decode to MIDI pitch (C4 = 60); `#` is a sharp, flats are deferred.
+- N tokens divide each cycle into N equal slots — same semantics as `seq(...)`. Empty / whitespace-only sources return `silence`.
+- Unknown tokens throw `MiniError('MINI_UNKNOWN_TOKEN')` with a `{ token }` details payload.
+- `parseNoteName(token)` is also exported as a standalone note-name → MIDI decoder for anyone parsing outside the mini grammar.
+
+New public API from `@loom/mini`:
+- `mini(source)` — returns `Pattern<MiniNote>` where `MiniNote = { pitch: number }`.
+- `parseNoteName(token)` — `string → number | undefined`.
+- `MiniError` / `MiniErrorCode` — stable error-code hierarchy for the mini layer.
+
+Out of v0 (per issue #12): `[x y]` groups (#26), `<x y>` alternation (#27), `*n`/`/n`/`@n` modifiers (#28), euclidean `x(k, n)` (#29).
+
+Closes #12.

--- a/src/mini/errors.ts
+++ b/src/mini/errors.ts
@@ -1,0 +1,22 @@
+/**
+ * Error codes raised by the mini-notation parser. Stable — renaming
+ * one is a breaking change.
+ */
+export type MiniErrorCode = 'MINI_UNKNOWN_TOKEN';
+
+/**
+ * Error thrown by the mini-notation parser. Carries a stable `code`
+ * and a machine-readable `details` payload naming (for example) the
+ * offending token.
+ */
+export class MiniError extends Error {
+  readonly code: MiniErrorCode;
+  readonly details: Readonly<Record<string, unknown>> | undefined;
+
+  constructor(code: MiniErrorCode, message: string, details?: Readonly<Record<string, unknown>>) {
+    super(message);
+    this.name = 'MiniError';
+    this.code = code;
+    this.details = details;
+  }
+}

--- a/src/mini/index.ts
+++ b/src/mini/index.ts
@@ -1,16 +1,3 @@
-// Mini-notation parser.
-//
-// v0 (#12):   space-separated tokens + rests `~`
-//               "c3 e3 ~ g3"  →  pattern of 4 steps
-//
-// v0.1 roadmap:
-//   #26  subdivision groups `[x y]`          nested step packing
-//   #27  alternation `<x y>`                 cycle-to-cycle variation
-//   #28  modifiers `*n` `/n` `@n`            inline time scaling
-//
-// v1 roadmap:
-//   #29  euclidean `x(k, n)`                 Bjorklund distribution
-//
-// Out of scope: polymetric `{x y}`, probability `x?p` — covered by
-// combinators in `src/transforms/` instead.
-export {};
+export { MiniError, type MiniErrorCode } from '@loom/mini/errors.js';
+export { parseNoteName } from '@loom/mini/note-name.js';
+export { mini, type MiniNote } from '@loom/mini/parse.js';

--- a/src/mini/note-name.test.ts
+++ b/src/mini/note-name.test.ts
@@ -1,0 +1,43 @@
+import { parseNoteName } from '@loom/mini/note-name.js';
+import { describe, expect, it } from 'vitest';
+
+describe('parseNoteName', () => {
+  it('parses natural notes in octave 4 — middle C family', () => {
+    expect(parseNoteName('c4')).toBe(60);
+    expect(parseNoteName('d4')).toBe(62);
+    expect(parseNoteName('e4')).toBe(64);
+    expect(parseNoteName('f4')).toBe(65);
+    expect(parseNoteName('g4')).toBe(67);
+    expect(parseNoteName('a4')).toBe(69);
+    expect(parseNoteName('b4')).toBe(71);
+  });
+
+  it('parses sharp notes', () => {
+    expect(parseNoteName('c#4')).toBe(61);
+    expect(parseNoteName('f#4')).toBe(66);
+    expect(parseNoteName('a#4')).toBe(70);
+  });
+
+  it('is case-insensitive on the note letter', () => {
+    expect(parseNoteName('C3')).toBe(48);
+    expect(parseNoteName('F#4')).toBe(66);
+  });
+
+  it('handles different octaves including negative', () => {
+    expect(parseNoteName('c3')).toBe(48);
+    expect(parseNoteName('c5')).toBe(72);
+    expect(parseNoteName('c0')).toBe(12);
+    expect(parseNoteName('c-1')).toBe(0);
+  });
+
+  it('returns undefined for unknown tokens', () => {
+    expect(parseNoteName('')).toBeUndefined();
+    expect(parseNoteName('c')).toBeUndefined(); // missing octave
+    expect(parseNoteName('h3')).toBeUndefined(); // invalid letter
+    expect(parseNoteName('c##3')).toBeUndefined(); // double sharp
+    expect(parseNoteName('c3.5')).toBeUndefined(); // fractional octave
+    expect(parseNoteName('3')).toBeUndefined(); // no letter
+    expect(parseNoteName('cat')).toBeUndefined(); // not a note
+    expect(parseNoteName('~')).toBeUndefined(); // rest marker isn't a note
+  });
+});

--- a/src/mini/note-name.ts
+++ b/src/mini/note-name.ts
@@ -1,0 +1,45 @@
+// Semitone offset from C for each note letter. Typed as a const
+// mapping so `letter` (typed as a key of this object) produces a
+// definite `number` on index — no defensive `undefined` branches.
+const LETTER_TO_SEMITONE = {
+  c: 0,
+  d: 2,
+  e: 4,
+  f: 5,
+  g: 7,
+  a: 9,
+  b: 11,
+} as const;
+
+type NoteLetter = keyof typeof LETTER_TO_SEMITONE;
+
+// Note letter, optional sharp accidental, octave (possibly negative).
+// The letter class `[a-g]` is exactly the key set of LETTER_TO_SEMITONE.
+const NOTE_PATTERN = /^([a-g])(#?)(-?\d+)$/;
+
+/**
+ * Parses a note-name token into a MIDI pitch (C4 = 60).
+ *
+ * Accepted syntax: `<letter><accidental?><octave>`, where:
+ * - `<letter>` is `a..g` (case-insensitive)
+ * - `<accidental>` is `#` (sharp) — optional. Flats are not yet
+ *   supported; callers who need `Eb3` write `d#3` instead.
+ * - `<octave>` is an integer, possibly negative
+ *
+ * @param token - Candidate note-name token (e.g. `"c3"`, `"f#4"`, `"c-1"`)
+ * @returns The MIDI pitch, or `undefined` if `token` isn't a valid note name
+ */
+export function parseNoteName(token: string): number | undefined {
+  const match = NOTE_PATTERN.exec(token.toLowerCase());
+  if (match === null) {
+    return undefined;
+  }
+  // Three mandatory capture groups — a successful match always
+  // populates all of them. `letter` is guaranteed to be in [a-g] by
+  // the letter class, so it's safely narrowed to `NoteLetter`.
+  const letter = match[1] as NoteLetter;
+  const sharp = match[2] as '' | '#';
+  const octaveStr = match[3] as string;
+  const octave = Number.parseInt(octaveStr, 10);
+  return (octave + 1) * 12 + LETTER_TO_SEMITONE[letter] + (sharp === '#' ? 1 : 0);
+}

--- a/src/mini/parse.test.ts
+++ b/src/mini/parse.test.ts
@@ -1,0 +1,93 @@
+// Side-effect imports for the interop tests — mini-produced Patterns
+// should chain cleanly through the pico8 setters and time transforms.
+import '@loom/pico8/augment.js';
+import '@loom/transforms/augment.js';
+
+import { Time } from '@loom/core/time.js';
+import { MiniError } from '@loom/mini/errors.js';
+import { mini } from '@loom/mini/parse.js';
+import { describe, expect, it } from 'vitest';
+
+describe('mini', () => {
+  it('parses a single note into one event per cycle', () => {
+    const events = mini('c3').query(Time.ZERO, Time.ONE);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.value).toEqual({ pitch: 48 });
+    expect(events[0]?.begin.eq(Time.ZERO)).toBe(true);
+    expect(events[0]?.end.eq(Time.ONE)).toBe(true);
+  });
+
+  it('splits N tokens into N equal slots within one cycle', () => {
+    const events = mini('c3 e3 g3 c4').query(Time.ZERO, Time.ONE);
+    expect(events.map((e) => e.value.pitch)).toEqual([48, 52, 55, 60]);
+    expect(events[0]?.end.eq(new Time(1n, 4n))).toBe(true);
+    expect(events[1]?.end.eq(new Time(1n, 2n))).toBe(true);
+    expect(events[2]?.end.eq(new Time(3n, 4n))).toBe(true);
+    expect(events[3]?.end.eq(Time.ONE)).toBe(true);
+  });
+
+  it('treats `~` as a rest (no event in that slot)', () => {
+    const events = mini('c3 e3 ~ g3').query(Time.ZERO, Time.ONE);
+    expect(events.map((e) => e.value.pitch)).toEqual([48, 52, 55]);
+    // Rest slot has no event; g3 fires at [3/4, 1).
+    expect(events[2]?.begin.eq(new Time(3n, 4n))).toBe(true);
+  });
+
+  it('handles leading/trailing/internal whitespace', () => {
+    const events = mini('  c3   e3\tg3  ').query(Time.ZERO, Time.ONE);
+    expect(events.map((e) => e.value.pitch)).toEqual([48, 52, 55]);
+  });
+
+  it('returns silence for an empty or whitespace-only source', () => {
+    expect(mini('').query(Time.ZERO, Time.ONE)).toEqual([]);
+    expect(mini('   ').query(Time.ZERO, Time.ONE)).toEqual([]);
+    expect(mini('\t\n').query(Time.ZERO, Time.ONE)).toEqual([]);
+  });
+
+  it('supports sharps via #', () => {
+    const events = mini('c3 c#3 d3').query(Time.ZERO, Time.ONE);
+    expect(events.map((e) => e.value.pitch)).toEqual([48, 49, 50]);
+  });
+
+  it('throws MINI_UNKNOWN_TOKEN on invalid tokens', () => {
+    try {
+      mini('c3 wobble g3');
+      expect.fail('expected throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(MiniError);
+      const err = error as MiniError;
+      expect(err.code).toBe('MINI_UNKNOWN_TOKEN');
+      expect(err.details).toEqual({ token: 'wobble' });
+    }
+  });
+
+  it('rejects note letters outside a-g (e.g. h)', () => {
+    try {
+      mini('h3');
+      expect.fail('expected throw');
+    } catch (error) {
+      expect((error as MiniError).code).toBe('MINI_UNKNOWN_TOKEN');
+    }
+  });
+
+  it('repeats across cycles', () => {
+    const events = mini('c3 e3').query(Time.ZERO, new Time(2n, 1n));
+    expect(events.map((e) => e.value.pitch)).toEqual([48, 52, 48, 52]);
+  });
+
+  describe('interop with pico8 setters and transforms', () => {
+    it('chains through .vol and .ch — the end-to-end story from issue #8', () => {
+      const events = mini('c3 e3').vol(5).ch(0).query(Time.ZERO, Time.ONE);
+      expect(events.map((e) => e.value)).toEqual([
+        { pitch: 48, vol: 5, ch: 0 },
+        { pitch: 52, vol: 5, ch: 0 },
+      ]);
+    });
+
+    it('composes with .fast — mini(...).fast(2) doubles event density', () => {
+      const events = mini('c3 e3').fast(2).query(Time.ZERO, Time.ONE);
+      expect(events.map((e) => e.value.pitch)).toEqual([48, 52, 48, 52]);
+      expect(events[0]?.end.eq(new Time(1n, 4n))).toBe(true);
+    });
+  });
+});

--- a/src/mini/parse.ts
+++ b/src/mini/parse.ts
@@ -1,0 +1,56 @@
+import { Pattern } from '@loom/core/pattern.js';
+import { pure, seq, silence } from '@loom/core/primitives.js';
+import { MiniError } from '@loom/mini/errors.js';
+import { parseNoteName } from '@loom/mini/note-name.js';
+
+/** The event-value shape emitted by `mini()` — just a MIDI pitch. */
+export interface MiniNote {
+  readonly pitch: number;
+}
+
+/**
+ * Parses a whitespace-separated mini-notation string into a Pattern.
+ *
+ * Tokens supported in v0:
+ * - **Note names** — `c3`, `d#4`, `f#-1`, etc. Decode to MIDI pitch
+ *   (`c4 = 60`). `#` is a sharp; flats are not yet supported
+ *   (write `d#3` for `Eb3`).
+ * - **Rest** — `~` produces no event for that slot.
+ *
+ * The N parsed tokens divide each cycle into N equal slots — same
+ * semantics as `seq(...)`. An empty / whitespace-only source returns
+ * `silence`.
+ *
+ * @param source - Whitespace-separated sequence of note/rest tokens
+ * @returns A Pattern emitting one `MiniNote` per note token, per cycle
+ * @throws `MiniError('MINI_UNKNOWN_TOKEN')` on any token that is
+ *   neither `~` nor a valid note name
+ */
+export function mini(source: string): Pattern<MiniNote> {
+  const tokens = source
+    .trim()
+    .split(/\s+/)
+    .filter((t) => t.length > 0);
+  if (tokens.length === 0) {
+    return silence;
+  }
+
+  const slots: Pattern<MiniNote>[] = tokens.map((token) => {
+    if (token === '~') {
+      return silence;
+    }
+    const pitch = parseNoteName(token);
+    if (pitch === undefined) {
+      throw new MiniError(
+        'MINI_UNKNOWN_TOKEN',
+        `Unknown mini-notation token: ${JSON.stringify(token)}`,
+        {
+          token,
+        },
+      );
+    }
+    return pure({ pitch });
+  });
+
+  return slots.length === 1 ? (slots[0] as Pattern<MiniNote>) : seq(...slots);
+}


### PR DESCRIPTION
## Summary

Ships the v0 mini-notation parser — a whitespace-separated sequence of note-name tokens and rest markers, lowered to a `Pattern<MiniNote>` where `MiniNote = { pitch: number }`.

### Tokens supported

- **Note names** — `c3`, `d#4`, `f#-1`, …
  - Letter `a..g` (case-insensitive)
  - Optional sharp `#`
  - Octave (integer, possibly negative) — MIDI pitch, C4 = 60
  - Flats deferred to [#51](https://github.com/salty-max/loom/issues/51)
- **Rest** — `~` produces no event for that slot

N tokens divide each cycle into N equal slots (`seq`-equivalent). Empty / whitespace-only sources return `silence`.

### Error handling

Unknown tokens throw `MiniError('MINI_UNKNOWN_TOKEN')` with a `{ token }` details payload — same stable-code + typed-details shape as `Pico8Error`.

### New public API from `@loom/mini`

- `mini(source)` — the parser.
- `MiniNote` — event-value shape.
- `parseNoteName(token)` — standalone note-name → MIDI decoder.
- `MiniError` / `MiniErrorCode` — error class hierarchy.

### Design notes

- **Layering:** `mini/` imports only from `@loom/core/*`. It's a peer of `pico8/` and `transforms/` under `core`. MIDI pitches are the lingua franca; `pico8` adapters handle range clamping at render time.
- **Regex-keyed typed map:** `NOTE_PATTERN`'s letter class `[a-g]` is exactly the key set of `LETTER_TO_SEMITONE`, so `letter as NoteLetter` casts are provably safe with no defensive `undefined` branches.
- **Single-token short-circuit:** `mini('c3')` returns the underlying `pure(...)` directly instead of `seq(pure(...))` — same semantics, one fewer allocation per query.

Closes #12.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` — 187 tests, includes interop with `.vol(5).ch(0)` and `.fast(2)` to lock the end-to-end story from issue #8
- [x] `bun run test:cov` — 100/98.44/100/100
- [x] `bunx --bun knip` clean
- [x] Changeset — minor bump on `loom`

## Review loop
Self-review LGTM'd with two non-blocking items, both applied per CLAUDE.md rule 4: interop tests added (landed in autosquashed fixup), follow-up filed as [#51](https://github.com/salty-max/loom/issues/51) for flat-accidental support.