### PR TITLE
feat(adapters): stdout JSON-per-line print adapter

### DIFF
--- a/.changeset/adapters-print.md
+++ b/.changeset/adapters-print.md
@@ -1,0 +1,11 @@
+---
+"loom": minor
+---
+
+**adapters:** ship `print(pattern, options)` — the simplest adapter, writing one JSON event per line to stdout.
+
+- `cycles` (required positive integer): how many cycles of the pattern to query.
+- `bpm` (optional positive finite number, defaults to `DEFAULT_BPM = 120`): used to derive wall-clock `beginMs` / `endMs` at `time.toNumber() * 60_000 / bpm`. **Always emitted** — the output shape is stable regardless of whether the caller supplies a bpm.
+- `sink` (optional `(line: string) => void`): defaults to `console.log`. CLI wrappers and tests can pass a spy / writable stream.
+
+Each line serializes `{ begin, end, value, beginMs, endMs }` where `begin`/`end` use `Time.toString()` (bare integer or `"num/den"`). `value` passes through verbatim. `Event.context` is intentionally dropped — it's a debug-only origin hint, not a consumer-visible field. The event stream is the canonical target for `loom events` (#17) and for tests exploring what a given pattern emits.

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,8 +1,8 @@
 // Output adapters — each renders a pattern to a specific output.
 //
-// Populated as the roadmap lands:
-// - print: stdout JSON events (for tests and CLI debug)
-// - web-audio: browser playback with the 8-bit chiptune synth
-// - midi: Web MIDI (browser) and node-midi (Node)
-// - osc: SuperCollider bridge
-export {};
+// Roadmap:
+// - print (#14): stdout JSON events (for tests and CLI debug)
+// - web-audio (#15): browser playback with the 8-bit chiptune synth
+// - midi (#16): Web MIDI (browser) and node-midi (Node)
+
+export { DEFAULT_BPM, print, type PrintedEvent, type PrintOptions } from '@loom/adapters/print.js';

--- a/src/adapters/print.test.ts
+++ b/src/adapters/print.test.ts
@@ -1,0 +1,145 @@
+import { DEFAULT_BPM, print } from '@loom/adapters/print.js';
+import { Pattern } from '@loom/core/pattern.js';
+import { pure, seq, silence } from '@loom/core/primitives.js';
+import { Time } from '@loom/core/time.js';
+import { describe, expect, it, vi } from 'vitest';
+
+function captured(): { sink: (line: string) => void; lines: string[] } {
+  const lines: string[] = [];
+  return {
+    sink: (line) => {
+      lines.push(line);
+    },
+    lines,
+  };
+}
+
+describe('print', () => {
+  it('emits one JSON line per event with Time.toString() formatting and default-bpm ms', () => {
+    const { sink, lines } = captured();
+    print(seq(pure('a'), pure('b')), { cycles: 1, sink });
+
+    expect(lines).toHaveLength(2);
+    // Default bpm is 120 → one cycle = 500ms, so each half spans 250ms.
+    expect(JSON.parse(lines[0] ?? '')).toEqual({
+      begin: '0',
+      end: '1/2',
+      value: 'a',
+      beginMs: 0,
+      endMs: 250,
+    });
+    expect(JSON.parse(lines[1] ?? '')).toEqual({
+      begin: '1/2',
+      end: '1',
+      value: 'b',
+      beginMs: 250,
+      endMs: 500,
+    });
+  });
+
+  it('renders integer Time values as bare integers, not "n/1"', () => {
+    const { sink, lines } = captured();
+    print(pure('x'), { cycles: 1, sink });
+
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0] ?? '')).toMatchObject({
+      begin: '0',
+      end: '1',
+      value: 'x',
+    });
+  });
+
+  it('queries N cycles when cycles=N', () => {
+    const { sink, lines } = captured();
+    print(pure('x'), { cycles: 3, sink });
+
+    expect(lines).toHaveLength(3);
+    const times = lines.map((l) => JSON.parse(l) as { begin: string; end: string });
+    expect(times.map((t) => t.begin)).toEqual(['0', '1', '2']);
+    expect(times.map((t) => t.end)).toEqual(['1', '2', '3']);
+  });
+
+  it('emits nothing for silence', () => {
+    const { sink, lines } = captured();
+    print(silence, { cycles: 2, sink });
+    expect(lines).toEqual([]);
+  });
+
+  it('preserves complex value shapes verbatim', () => {
+    const { sink, lines } = captured();
+    print(pure({ pitch: 48, vol: 5 }), { cycles: 1, sink });
+
+    expect(JSON.parse(lines[0] ?? '')).toMatchObject({
+      begin: '0',
+      end: '1',
+      value: { pitch: 48, vol: 5 },
+    });
+  });
+
+  it('drops Event.context — it is a debug-only field, not part of the stream', () => {
+    // Lock the behaviour: even when the underlying Pattern carries a
+    // context, the printed line never surfaces it.
+    const source = new Pattern<string>(() => [
+      { begin: Time.ZERO, end: Time.ONE, value: 'x', context: { origin: 'mini' } },
+    ]);
+    const { sink, lines } = captured();
+    print(source, { cycles: 1, sink });
+
+    const parsed = JSON.parse(lines[0] ?? '') as Record<string, unknown>;
+    expect(parsed).not.toHaveProperty('context');
+  });
+
+  describe('bpm option', () => {
+    it('DEFAULT_BPM is 120', () => {
+      expect(DEFAULT_BPM).toBe(120);
+    });
+
+    it('scales correctly at non-default bpm', () => {
+      const { sink, lines } = captured();
+      // At 60 bpm, one cycle = 1000ms.
+      print(pure('x'), { cycles: 2, bpm: 60, sink });
+
+      expect(JSON.parse(lines[0] ?? '')).toMatchObject({ beginMs: 0, endMs: 1000 });
+      expect(JSON.parse(lines[1] ?? '')).toMatchObject({ beginMs: 1000, endMs: 2000 });
+    });
+
+    it('produces 500ms-per-cycle at the default of 120 bpm', () => {
+      const { sink, lines } = captured();
+      print(pure('x'), { cycles: 2, sink });
+
+      expect(JSON.parse(lines[0] ?? '')).toMatchObject({ beginMs: 0, endMs: 500 });
+      expect(JSON.parse(lines[1] ?? '')).toMatchObject({ beginMs: 500, endMs: 1000 });
+    });
+  });
+
+  describe('validation', () => {
+    it('rejects non-positive / non-integer cycles', () => {
+      for (const bad of [0, -1, 1.5, Number.NaN]) {
+        expect(() => {
+          print(pure('x'), { cycles: bad });
+        }).toThrow(TypeError);
+      }
+    });
+
+    it('rejects non-positive or non-finite bpm', () => {
+      for (const bad of [0, -120, Number.NaN, Number.POSITIVE_INFINITY]) {
+        expect(() => {
+          print(pure('x'), { cycles: 1, bpm: bad });
+        }).toThrow(TypeError);
+      }
+    });
+  });
+
+  it('defaults the sink to console.log when not provided', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      print(pure('x'), { cycles: 1 });
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(
+        '{"begin":"0","end":"1","value":"x","beginMs":0,"endMs":500}',
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/src/adapters/print.ts
+++ b/src/adapters/print.ts
@@ -1,0 +1,71 @@
+import type { Pattern } from '@loom/core/pattern.js';
+import { Time } from '@loom/core/time.js';
+
+/** Default tempo used when {@link PrintOptions.bpm} is omitted. */
+export const DEFAULT_BPM = 120;
+
+/** Options accepted by {@link print}. */
+export interface PrintOptions {
+  /** Positive integer — how many cycles to query. */
+  readonly cycles: number;
+  /**
+   * Tempo in beats per minute. Defaults to {@link DEFAULT_BPM} (120).
+   * Wall-clock `beginMs` / `endMs` are computed as
+   * `time.toNumber() * 60_000 / bpm`.
+   */
+  readonly bpm?: number;
+  /**
+   * Optional sink for the emitted lines. Defaults to `console.log`.
+   * Tests and CLI wrappers can redirect by passing a spy.
+   */
+  readonly sink?: (line: string) => void;
+}
+
+/** Shape of one line of output — JSON per line. */
+export interface PrintedEvent {
+  readonly begin: string;
+  readonly end: string;
+  readonly value: unknown;
+  readonly beginMs: number;
+  readonly endMs: number;
+}
+
+/**
+ * Queries `pattern` over `[0, cycles)` and emits one JSON line per
+ * event to `sink` (default `console.log`). Each line carries:
+ *
+ * - `begin` / `end` rendered via `Time.toString()` (bare integer or
+ *   `"num/den"`).
+ * - `value` — the event payload verbatim. `Event.context` is
+ *   intentionally omitted; it's a debug-only origin hint, not a
+ *   consumer-visible field.
+ * - `beginMs` / `endMs` — wall-clock timestamps at `bpm` (default 120).
+ *
+ * Used by `loom events` (#17) and by tests exploring pattern output.
+ *
+ * @param pattern - Pattern to query
+ * @param options - Cycle count, optional bpm, optional sink
+ * @throws `TypeError` when `cycles` is not a positive integer or
+ *   `bpm` is not a positive finite number
+ */
+export function print<T>(pattern: Pattern<T>, options: PrintOptions): void {
+  const { cycles, bpm = DEFAULT_BPM, sink = console.log } = options;
+  if (!Number.isInteger(cycles) || cycles <= 0) {
+    throw new TypeError(`print: cycles must be a positive integer, got ${cycles}`);
+  }
+  if (!Number.isFinite(bpm) || bpm <= 0) {
+    throw new TypeError(`print: bpm must be a positive finite number, got ${bpm}`);
+  }
+
+  const events = pattern.query(Time.ZERO, new Time(BigInt(cycles), 1n));
+  for (const event of events) {
+    const line: PrintedEvent = {
+      begin: event.begin.toString(),
+      end: event.end.toString(),
+      value: event.value,
+      beginMs: (event.begin.toNumber() * 60_000) / bpm,
+      endMs: (event.end.toNumber() * 60_000) / bpm,
+    };
+    sink(JSON.stringify(line));
+  }
+}


### PR DESCRIPTION
## Summary

Adds the simplest adapter — queries a Pattern over `[0, cycles)` and writes one JSON event per line to `stdout` (or a caller-supplied sink).

### Output shape (stable, one JSON per line)

```json
{"begin":"0","end":"1/2","value":"a","beginMs":0,"endMs":250}
```

- `begin` / `end` — rendered via `Time.toString()` (bare integer or `"num/den"`).
- `value` — event payload verbatim. `Event.context` is intentionally dropped (debug-only hint).
- `beginMs` / `endMs` — wall-clock timestamps at `bpm` (default 120). **Always emitted** for a stable output shape downstream consumers can rely on without branching.

### Options

- `cycles` (required positive integer).
- `bpm` (optional positive finite, defaults to `DEFAULT_BPM = 120`).
- `sink` (optional `(line: string) => void`, defaults to `console.log`). Lets CLI wrappers route to `process.stdout.write` and lets tests pass a spy.

### Validation

`TypeError` on ill-typed inputs (non-positive / non-integer `cycles`, non-positive / non-finite `bpm`). These are structural programmer errors — print has no domain of its own, so unlike `Pico8Error` there's no coded hierarchy here.

Closes #14.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` — 199 tests
- [x] `bun run test:cov` — 100/98.56/100/100
- [x] Changeset — minor bump on `loom`

## Review loop
Self-review flagged the AC's bpm interpretation (the "default 120" wording implied the default should always apply, not just when bpm was omitted from the call). Addressed via autosquashed fixup:

- `bpm` now defaults to 120 and ms fields are **always emitted**.
- `DEFAULT_BPM = 120` exported as a named constant.
- Also locked: `Event.context` drop test, `60_000 / bpm` ordering aligned with the JSDoc expression.

LGTM at round 2.