### PR TITLE
feat(cli): 'loom events <file>' command

### DIFF
--- a/.changeset/cli-events.md
+++ b/.changeset/cli-events.md
@@ -1,0 +1,16 @@
+---
+"loom": minor
+---
+
+**cli:** ship `loom events <file> [--cycles N] [--bpm B]` — the first concrete CLI command.
+
+- Loads `<file>` via dynamic `import`, takes the module's `default` export as a Pattern, and pipes it through the print adapter.
+- `--cycles N` defaults to 1; `--bpm B` defaults to `DEFAULT_BPM` (120).
+- Structured exit codes: 0 on success, 1 on any parse / load / render error, each with a concise `loom events:` stderr message.
+- Non-Pattern default exports fail with a clear `must default-export a Pattern` message.
+
+Also restructures the CLI into `src/cli.ts` (thin entry) + `src/cli/args.ts` + `src/cli/events.ts` so commands can live side-by-side as the v0.1 `play` / `render` commands come online.
+
+**Deferred to [#54](https://github.com/salty-max/loom/issues/54):** the AC's "sandboxed import surface (only `loom/*` paths resolvable)" constraint. The current CLI uses a plain dynamic import — user files can pull in anything Node/Bun resolves. A follow-up issue tracks adding a pre-flight import-allowlist check.
+
+Closes #17.

--- a/knip.json
+++ b/knip.json
@@ -6,5 +6,6 @@
     "src/runtime/index.ts"
   ],
   "project": ["src/**/*.ts"],
+  "ignore": ["src/**/__fixtures__/**"],
   "ignoreExportsUsedInFile": true
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-// Loom CLI. Scaffolded — commands (events, play, render, repl) are tracked
-// as GitHub issues under the `cli` scope.
+import { runEvents } from '@loom/cli/events.js';
 
 const USAGE = `loom — a pattern-algebra DSL for algorithmic music
 
@@ -9,23 +8,41 @@ usage:
   loom <command> [args]
 
 commands:
-  events <file>    print JSON events for one cycle of the given pattern
+  events <file> [--cycles N] [--bpm B]
+                   print JSON events for N cycles of the pattern
+                   default-exported by <file>, one JSON per line
   play   <file>    real-time playback via the web-audio adapter (TODO)
   render <file>    render the pattern to a .wav file (TODO)
   repl             live-coding REPL (TODO)
-
-This is the v0 scaffold — commands are not implemented yet.
-See CLAUDE.md for the PICO-8 scope boundary and the roadmap issues for
-the planned implementation order.
 `;
 
 const command = process.argv[2];
 
-if (!command || command === '--help' || command === '-h') {
+if (command === undefined || command === '--help' || command === '-h') {
   process.stdout.write(USAGE);
   process.exit(0);
 }
 
-process.stderr.write(`loom: unknown command "${command}"\n`);
-process.stderr.write(USAGE);
-process.exit(1);
+async function main(): Promise<number> {
+  switch (command) {
+    case 'events': {
+      return runEvents(process.argv.slice(3));
+    }
+    default: {
+      process.stderr.write(`loom: unknown command "${command}"\n`);
+      process.stderr.write(USAGE);
+      return 1;
+    }
+  }
+}
+
+main()
+  .then((code) => {
+    process.exit(code);
+  })
+  .catch((error: unknown) => {
+    process.stderr.write(
+      `loom: uncaught error: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exit(1);
+  });

--- a/src/cli/__fixtures__/no-default-export.ts
+++ b/src/cli/__fixtures__/no-default-export.ts
@@ -1,0 +1,3 @@
+// Only named exports — no default. Exercises the CLI's guard when
+// module.default is undefined.
+export const notDefault = 'hi';

--- a/src/cli/__fixtures__/not-a-pattern.ts
+++ b/src/cli/__fixtures__/not-a-pattern.ts
@@ -1,0 +1,3 @@
+// Default export isn't a Pattern — used to exercise the CLI's
+// type guard.
+export default { not: 'a pattern' };

--- a/src/cli/__fixtures__/simple.ts
+++ b/src/cli/__fixtures__/simple.ts
@@ -1,0 +1,4 @@
+import { pure, seq } from '@loom/core/primitives.js';
+
+// Default export: a two-slot pattern `a` then `b` per cycle.
+export default seq(pure('a'), pure('b'));

--- a/src/cli/__fixtures__/throwing-pattern.ts
+++ b/src/cli/__fixtures__/throwing-pattern.ts
@@ -1,0 +1,7 @@
+import { Pattern } from '@loom/core/pattern.js';
+
+// Default export is a Pattern whose query throws — exercises the
+// CLI's render-time error path.
+export default new Pattern(() => {
+  throw new Error('boom');
+});

--- a/src/cli/__fixtures__/throws-at-import.ts
+++ b/src/cli/__fixtures__/throws-at-import.ts
@@ -1,0 +1,2 @@
+// Throws at module load — exercises the CLI's dynamic-import try/catch.
+throw new Error('boom-at-import');

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -1,0 +1,78 @@
+import { parseEventsArgs } from '@loom/cli/args.js';
+import { describe, expect, it } from 'vitest';
+
+describe('parseEventsArgs', () => {
+  it('parses a lone file argument with defaults', () => {
+    expect(parseEventsArgs(['song.loom.ts'])).toEqual({ file: 'song.loom.ts', cycles: 1 });
+  });
+
+  it('parses --cycles after the file', () => {
+    expect(parseEventsArgs(['song.loom.ts', '--cycles', '4'])).toEqual({
+      file: 'song.loom.ts',
+      cycles: 4,
+    });
+  });
+
+  it('parses --bpm after the file', () => {
+    expect(parseEventsArgs(['song.loom.ts', '--bpm', '140'])).toEqual({
+      file: 'song.loom.ts',
+      cycles: 1,
+      bpm: 140,
+    });
+  });
+
+  it('parses both flags in either order', () => {
+    expect(parseEventsArgs(['song.loom.ts', '--cycles', '3', '--bpm', '120'])).toEqual({
+      file: 'song.loom.ts',
+      cycles: 3,
+      bpm: 120,
+    });
+    expect(parseEventsArgs(['song.loom.ts', '--bpm', '120', '--cycles', '3'])).toEqual({
+      file: 'song.loom.ts',
+      cycles: 3,
+      bpm: 120,
+    });
+  });
+
+  it('rejects a missing file', () => {
+    expect(parseEventsArgs([])).toEqual({ error: 'missing <file> argument' });
+    expect(parseEventsArgs(['--cycles', '2'])).toEqual({ error: 'missing <file> argument' });
+  });
+
+  it('rejects --cycles without a value', () => {
+    expect(parseEventsArgs(['song.loom.ts', '--cycles'])).toEqual({
+      error: '--cycles requires a value',
+    });
+  });
+
+  it('rejects --bpm without a value', () => {
+    expect(parseEventsArgs(['song.loom.ts', '--bpm'])).toEqual({
+      error: '--bpm requires a value',
+    });
+  });
+
+  it('rejects non-positive / non-integer --cycles', () => {
+    for (const bad of ['0', '1.5', 'abc']) {
+      const result = parseEventsArgs(['song.loom.ts', '--cycles', bad]);
+      expect('error' in result && result.error).toMatch(/positive integer/);
+    }
+  });
+
+  it('rejects non-positive / non-finite --bpm', () => {
+    for (const bad of ['0', '-120', 'abc']) {
+      const result = parseEventsArgs(['song.loom.ts', '--bpm', bad]);
+      expect('error' in result && result.error).toMatch(/positive finite/);
+    }
+  });
+
+  it('rejects unknown flags', () => {
+    expect(parseEventsArgs(['song.loom.ts', '--nope'])).toEqual({
+      error: 'unknown flag --nope',
+    });
+  });
+
+  it('rejects a second positional argument', () => {
+    const result = parseEventsArgs(['song.loom.ts', 'other.loom.ts']);
+    expect('error' in result && result.error).toMatch(/unexpected positional/);
+  });
+});

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,0 +1,67 @@
+/** Parsed argument shape for the `loom events` command. */
+export interface EventsArgs {
+  readonly file: string;
+  readonly cycles: number;
+  readonly bpm?: number;
+}
+
+/**
+ * Parses argv tail (everything after `loom events`) into a
+ * validated {@link EventsArgs} shape.
+ *
+ * Accepts: `<file> [--cycles N] [--bpm B]`. Unknown flags, missing
+ * file, or malformed numeric values produce a human-readable error
+ * string the caller can route to stderr.
+ *
+ * @param argv - Remaining argv after the subcommand token
+ * @returns Parsed args, or `{ error }` on a malformed invocation
+ */
+export function parseEventsArgs(argv: readonly string[]): EventsArgs | { readonly error: string } {
+  let file: string | undefined;
+  let cycles = 1;
+  let bpm: number | undefined;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--cycles') {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { error: `--cycles requires a value` };
+      }
+      const parsed = Number(value);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        return { error: `--cycles must be a positive integer, got ${value}` };
+      }
+      cycles = parsed;
+      i += 1;
+      continue;
+    }
+    if (arg === '--bpm') {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        return { error: `--bpm requires a value` };
+      }
+      const parsed = Number(value);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        return { error: `--bpm must be a positive finite number, got ${value}` };
+      }
+      bpm = parsed;
+      i += 1;
+      continue;
+    }
+    if (arg !== undefined && arg.startsWith('--')) {
+      return { error: `unknown flag ${arg}` };
+    }
+    if (file === undefined && arg !== undefined) {
+      file = arg;
+      continue;
+    }
+    return { error: `unexpected positional argument ${JSON.stringify(arg)}` };
+  }
+
+  if (file === undefined) {
+    return { error: `missing <file> argument` };
+  }
+
+  return bpm === undefined ? { file, cycles } : { file, cycles, bpm };
+}

--- a/src/cli/events.test.ts
+++ b/src/cli/events.test.ts
@@ -1,0 +1,147 @@
+import { fileURLToPath } from 'node:url';
+
+import { runEvents } from '@loom/cli/events.js';
+import { describe, expect, it, vi } from 'vitest';
+
+const FIXTURES = fileURLToPath(new URL('__fixtures__/', import.meta.url));
+
+function captured(): {
+  sinks: { stdout: (line: string) => void; stderr: (line: string) => void };
+  stdout: string[];
+  stderr: string[];
+} {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    sinks: {
+      stdout: (line) => {
+        stdout.push(line);
+      },
+      stderr: (line) => {
+        stderr.push(line);
+      },
+    },
+    stdout,
+    stderr,
+  };
+}
+
+describe('runEvents', () => {
+  it('prints one JSON line per event and exits 0', async () => {
+    const { sinks, stdout, stderr } = captured();
+    const code = await runEvents([`${FIXTURES}simple.ts`], sinks);
+
+    expect(code).toBe(0);
+    expect(stderr).toEqual([]);
+    expect(stdout).toHaveLength(2);
+    expect(JSON.parse(stdout[0] ?? '')).toMatchObject({ begin: '0', end: '1/2', value: 'a' });
+    expect(JSON.parse(stdout[1] ?? '')).toMatchObject({ begin: '1/2', end: '1', value: 'b' });
+  });
+
+  it('respects --cycles', async () => {
+    const { sinks, stdout } = captured();
+    const code = await runEvents([`${FIXTURES}simple.ts`, '--cycles', '2'], sinks);
+
+    expect(code).toBe(0);
+    expect(stdout).toHaveLength(4);
+  });
+
+  it('respects --bpm for ms timestamps', async () => {
+    const { sinks, stdout } = captured();
+    const code = await runEvents([`${FIXTURES}simple.ts`, '--bpm', '60'], sinks);
+
+    expect(code).toBe(0);
+    // At 60 bpm, one cycle = 1000ms, each half = 500ms.
+    expect(JSON.parse(stdout[0] ?? '')).toMatchObject({ beginMs: 0, endMs: 500 });
+    expect(JSON.parse(stdout[1] ?? '')).toMatchObject({ beginMs: 500, endMs: 1000 });
+  });
+
+  it('exits 1 with an arg-parse error on malformed flags', async () => {
+    const { sinks, stdout, stderr } = captured();
+    const code = await runEvents([`${FIXTURES}simple.ts`, '--cycles', 'abc'], sinks);
+
+    expect(code).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr).toHaveLength(1);
+    expect(stderr[0]).toContain('--cycles must be a positive integer');
+  });
+
+  it('exits 1 with a clear message when the file cannot be loaded', async () => {
+    const { sinks, stdout, stderr } = captured();
+    const code = await runEvents([`${FIXTURES}does-not-exist.ts`], sinks);
+
+    expect(code).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr[0]).toContain('failed to load');
+    expect(stderr[0]).toContain('does-not-exist.ts');
+  });
+
+  it("exits 1 when the file's default export is not a Pattern", async () => {
+    const { sinks, stdout, stderr } = captured();
+    const code = await runEvents([`${FIXTURES}not-a-pattern.ts`], sinks);
+
+    expect(code).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr[0]).toContain('must default-export a Pattern');
+  });
+
+  it('exits 1 with no stdout output on missing file argument', async () => {
+    const { sinks, stdout, stderr } = captured();
+    const code = await runEvents([], sinks);
+
+    expect(code).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr[0]).toContain('missing <file>');
+  });
+
+  it('exits 1 when the default-exported Pattern throws at query time', async () => {
+    const { sinks, stdout, stderr } = captured();
+    const code = await runEvents([`${FIXTURES}throwing-pattern.ts`], sinks);
+
+    expect(code).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr[0]).toContain('boom');
+  });
+
+  it('exits 1 when the file throws at module load time', async () => {
+    const { sinks, stdout, stderr } = captured();
+    const code = await runEvents([`${FIXTURES}throws-at-import.ts`], sinks);
+
+    expect(code).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr[0]).toContain('failed to load');
+    expect(stderr[0]).toContain('boom-at-import');
+  });
+
+  it('exits 1 when the file has no default export', async () => {
+    const { sinks, stdout, stderr } = captured();
+    const code = await runEvents([`${FIXTURES}no-default-export.ts`], sinks);
+
+    expect(code).toBe(1);
+    expect(stdout).toEqual([]);
+    expect(stderr[0]).toContain('must default-export a Pattern');
+    expect(stderr[0]).toContain('got undefined');
+  });
+
+  it('writes to process.stdout / process.stderr by default when no sinks injected', async () => {
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      // Happy path hits the default stdout sink.
+      const okCode = await runEvents([`${FIXTURES}simple.ts`]);
+      expect(okCode).toBe(0);
+      expect(stdoutSpy).toHaveBeenCalled();
+
+      stdoutSpy.mockClear();
+      stderrSpy.mockClear();
+
+      // Error path hits the default stderr sink.
+      const errCode = await runEvents([]);
+      expect(errCode).toBe(1);
+      expect(stderrSpy).toHaveBeenCalled();
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    }
+  });
+});

--- a/src/cli/events.ts
+++ b/src/cli/events.ts
@@ -1,0 +1,78 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { print } from '@loom/adapters/print.js';
+import { parseEventsArgs } from '@loom/cli/args.js';
+import { Pattern } from '@loom/core/pattern.js';
+
+/** Sinks the `loom events` command writes to. Injectable for tests. */
+export interface EventsSinks {
+  readonly stdout: (line: string) => void;
+  readonly stderr: (line: string) => void;
+}
+
+const DEFAULT_SINKS: EventsSinks = {
+  stdout: (line) => {
+    process.stdout.write(`${line}\n`);
+  },
+  stderr: (line) => {
+    process.stderr.write(`${line}\n`);
+  },
+};
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Runs the `loom events <file> [--cycles N] [--bpm B]` command.
+ *
+ * Loads the source file via dynamic `import`, takes the module's
+ * `default` export as a Pattern, and feeds it through the `print`
+ * adapter. Returns the process exit code — 0 on success, 1 on any
+ * parse / load / render error.
+ *
+ * @param argv - Argv tail (the `<file>` + flags, not including `events`)
+ * @param sinks - Optional stdout/stderr writers; defaults to process streams
+ * @returns Exit code (0 = success, non-zero = error)
+ */
+export async function runEvents(
+  argv: readonly string[],
+  sinks: EventsSinks = DEFAULT_SINKS,
+): Promise<number> {
+  const parsed = parseEventsArgs(argv);
+  if ('error' in parsed) {
+    sinks.stderr(`loom events: ${parsed.error}`);
+    return 1;
+  }
+
+  const resolved = path.resolve(parsed.file);
+  let module: { default?: unknown };
+  try {
+    module = (await import(pathToFileURL(resolved).href)) as { default?: unknown };
+  } catch (error) {
+    sinks.stderr(`loom events: failed to load ${parsed.file}: ${formatError(error)}`);
+    return 1;
+  }
+
+  const pattern = module.default;
+  if (!(pattern instanceof Pattern)) {
+    sinks.stderr(
+      `loom events: ${parsed.file} must default-export a Pattern (got ${typeof pattern})`,
+    );
+    return 1;
+  }
+
+  try {
+    print(pattern, {
+      cycles: parsed.cycles,
+      ...(parsed.bpm === undefined ? {} : { bpm: parsed.bpm }),
+      sink: sinks.stdout,
+    });
+  } catch (error) {
+    sinks.stderr(`loom events: ${formatError(error)}`);
+    return 1;
+  }
+
+  return 0;
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "test", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "test", "**/*.test.ts", "**/__fixtures__/**"]
 }


### PR DESCRIPTION
## Summary

First concrete CLI command — **closes the final v0 issue**. Loads a user's `.loom.ts` source, takes the module's `default` export as a `Pattern`, and pipes it through the print adapter.

### Usage

```
loom events <file> [--cycles N] [--bpm B]
```

Both flags default to the print-adapter defaults (cycles=1, bpm=120). Output is one JSON line per event on stdout. Errors (parse, load, non-Pattern default, query-time throw) exit 1 with a `loom events:` stderr message.

### Structure

- `src/cli.ts` — thin entry: parses argv, dispatches to the command, calls `process.exit` with the returned code.
- `src/cli/args.ts` — pure `parseEventsArgs(argv)`; returns either the validated shape or `{ error }`.
- `src/cli/events.ts` — `runEvents(argv, sinks?)` returns a `Promise<number>` exit code. Injectable sinks make it pure and testable.
- `src/cli/__fixtures__/` — five fixtures covering happy path, no-default-export, non-Pattern default, throws-at-import, throws-at-query. Excluded from the build (`tsconfig.build.json`) and from knip's unused-file check.

### Deferred (tracked)

The AC's "sandboxed import surface (only `loom/*` paths resolvable)" is the one gap — the current CLI uses a plain dynamic `import()`, so user files can pull in anything Node/Bun resolves. Filed as [#54](https://github.com/salty-max/loom/issues/54) with a proposed static-analysis pre-flight.

Closes #17.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` — 221 tests, every failure path covered
- [x] `bun run test:cov` — 100/98.29/100/100
- [x] `bunx --bun knip` clean (fixtures ignored)
- [x] `bun run build` — `dist/cli/__fixtures__` is NOT emitted (verified)
- [x] End-to-end smoke: `bun run cli events src/cli/__fixtures__/simple.ts --bpm 60` produces valid JSONL
- [x] Changeset — minor bump on `loom`

## Review loop
Self-review flagged one required change (fixtures bleeding into `dist/` + knip flagging them as unused) plus two non-blocking test additions. All applied per CLAUDE.md rule 4: fixtures excluded from both `tsconfig.build.json` and `knip.json`, no-default-export and throws-at-import fixtures + tests added. LGTM at round 2.

---

🎉 **v0 backlog complete** after this merge — all 14 milestone issues closed.